### PR TITLE
Fix NUM_DRAFTS p1p1 bug and GIH_WR_STDEV typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ A table of all included columns. Columns can be referenced by enum or by string 
 | `GIH_WR_MEAN` | `"gih_wr_mean"` | | `AGG` | `WON_GIH_TOTAL` / `GIH_TOTAL` | Float |
 | `GIH_WR_EXCESS` | `"gih_wr_excess"` | | `AGG` | `GIH_WR - GIH_WR_MEAN` | Float |
 | `GIH_WR_VAR` | `"gih_wr_var"` | | `AGG` | Game-weighted Variance | Float |
-| `GIH_WR_STDEV` | `"gh_wr_stdev"` | | `AGG` | Sqrt of `GIH_WR_VAR` | Float |
+| `GIH_WR_STDEV` | `"gih_wr_stdev"` | | `AGG` | Sqrt of `GIH_WR_VAR` | Float |
 | `GIH_WR_Z` | `"gih_wr_z"` | | `AGG` |`GIH_WR_EXCESS` / `GIH_WR_STDEV` | Float |
 | `DECK_MANA_VALUE_AVG` | `"deck_mana_value_avg"` | | `AGG` | `DECK_MANA_VALUE ` / `DECK_SPELLS` | Float |
 | `DECK_LANDS_AVG` | `"deck_lands_avg"` | | `AGG` | `DECK_LANDS ` / `NUM_GAMES` | Float |

--- a/spells/columns.py
+++ b/spells/columns.py
@@ -14,6 +14,9 @@ class ColSpec:
     version: str | None = None
 
 
+P1P1_MISSING_SETS = frozenset({"TLA", "TMT", "ECL"})
+
+
 @dataclass(frozen=True)
 class ColDef:
     name: str
@@ -187,10 +190,14 @@ _specs: dict[str, ColSpec] = {
     ColName.NUM_DRAFTS: ColSpec(
         col_type=ColType.PICK_SUM,
         expr=pl.when(
-            (pl.col(ColName.PACK_NUMBER) == 0) & (pl.col(ColName.PICK_NUMBER) == 1)
-        ) # use p1p2 since some datasets are missing p1p1
-        .then(1)
-        .otherwise(0),
+            (pl.col(ColName.PACK_NUMBER) == 0)
+            & (
+                pl.col(ColName.PICK_NUMBER)
+                == pl.when(pl.col(ColName.EXPANSION).is_in(P1P1_MISSING_SETS))
+                .then(1)
+                .otherwise(0)
+            )
+        ).then(1).otherwise(0),
     ),
     ColName.PICK: ColSpec(
         col_type=ColType.FILTER_ONLY,

--- a/spells/enums.py
+++ b/spells/enums.py
@@ -162,7 +162,7 @@ class ColName(StrEnum):
     GIH_WR_MEAN = "gih_wr_mean"
     GIH_WR_EXCESS = "gih_wr_excess"
     GIH_WR_VAR = "gih_wr_var"
-    GIH_WR_STDEV = "gh_wr_stdev"
+    GIH_WR_STDEV = "gih_wr_stdev"
     GIH_WR_Z = "gih_wr_z"
     DECK_MANA_VALUE_AVG = "deck_mana_value_avg"
     DECK_LANDS_AVG = "deck_lands_avg"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import datetime
 import json
 import os
 
+import polars as pl
 import pytest
 
 import spells.cache as cache
@@ -11,6 +12,128 @@ from spells.draft_data import get_names
 FAKE_SET = "TST"
 FAKE_START = datetime.date(2026, 1, 1)
 FAKE_END = datetime.date(2026, 1, 2)
+
+FAKE_CARD_NAMES = ["Aether Sprite", "Blazing Howl", "Crystal Warden"]
+
+# Card attribute rows matching the CardAttr enum fields written by cards.py.
+FAKE_CARD_ATTR_ROWS = [
+    {
+        "name": "Aether Sprite",
+        "set_code": "TST",
+        "color": "U",
+        "rarity": "common",
+        "color_identity": "U",
+        "card_type": "Creature",
+        "subtype": "Faerie",
+        "mana_value": 2.0,
+        "mana_cost": "{1}{U}",
+        "power": "1",
+        "toughness": "1",
+        "is_bonus_sheet": False,
+        "is_dfc": False,
+        "oracle_text": "Flying",
+        "card_json": "{}",
+        "scryfall_id": "",
+        "image_url": "",
+    },
+    {
+        "name": "Blazing Howl",
+        "set_code": "TST",
+        "color": "R",
+        "rarity": "uncommon",
+        "color_identity": "R",
+        "card_type": "Instant",
+        "subtype": "",
+        "mana_value": 1.0,
+        "mana_cost": "{R}",
+        "power": None,
+        "toughness": None,
+        "is_bonus_sheet": False,
+        "is_dfc": False,
+        "oracle_text": "Target creature gets +2/+0 until end of turn.",
+        "card_json": "{}",
+        "scryfall_id": "",
+        "image_url": "",
+    },
+    {
+        "name": "Crystal Warden",
+        "set_code": "TST",
+        "color": "W",
+        "rarity": "rare",
+        "color_identity": "W",
+        "card_type": "Creature",
+        "subtype": "Human Soldier",
+        "mana_value": 3.0,
+        "mana_cost": "{2}{W}",
+        "power": "3",
+        "toughness": "3",
+        "is_bonus_sheet": False,
+        "is_dfc": False,
+        "oracle_text": "Vigilance",
+        "card_json": "{}",
+        "scryfall_id": "",
+        "image_url": "",
+    },
+]
+
+
+def _make_draft_row(set_code, draft_id, pack_number, pick_number, pick):
+    """One pick row: all 3 fake cards present in pack, one picked."""
+    row = {
+        "expansion": set_code,
+        "event_type": "PremierDraft",
+        "draft_id": draft_id,
+        "draft_time": "2026-01-01",
+        "rank": "Gold",
+        "event_match_wins": 0,
+        "event_match_losses": 0,
+        "pack_number": pack_number,
+        "pick_number": pick_number,
+        "pick": pick,
+        "pick_maindeck_rate": 1.0,
+        "pick_sideboard_in_rate": 0.0,
+        "user_n_games_bucket": 200,
+        "user_game_win_rate_bucket": 0.55,
+    }
+    for name in FAKE_CARD_NAMES:
+        row[f"pack_card_{name}"] = 1
+        row[f"pool_{name}"] = 0
+    return row
+
+
+def _write_set_parquets(external_dir, set_code, draft_rows):
+    """Write card, context, and draft parquets for a fake set."""
+    set_dir = external_dir / set_code
+    set_dir.mkdir(parents=True)
+
+    card_rows = [{**r, "set_code": set_code} for r in FAKE_CARD_ATTR_ROWS]
+    pl.DataFrame(card_rows).write_parquet(set_dir / f"{set_code}_card.parquet")
+
+    pl.DataFrame(
+        {"release_date": [datetime.date(2026, 1, 1)], "picks_per_pack": [14]}
+    ).write_parquet(set_dir / f"{set_code}_context.parquet")
+
+    schema = {
+        "expansion": pl.String,
+        "event_type": pl.String,
+        "draft_id": pl.String,
+        "draft_time": pl.String,
+        "rank": pl.String,
+        "event_match_wins": pl.Int8,
+        "event_match_losses": pl.Int8,
+        "pack_number": pl.Int8,
+        "pick_number": pl.Int8,
+        "pick": pl.String,
+        "pick_maindeck_rate": pl.Float64,
+        "pick_sideboard_in_rate": pl.Float64,
+        "user_n_games_bucket": pl.Int16,
+        "user_game_win_rate_bucket": pl.Float64,
+        **{f"pack_card_{n}": pl.Int8 for n in FAKE_CARD_NAMES},
+        **{f"pool_{n}": pl.Int8 for n in FAKE_CARD_NAMES},
+    }
+    pl.DataFrame(draft_rows, schema=schema).write_parquet(
+        set_dir / f"{set_code}_PremierDraft_draft.parquet"
+    )
 
 FAKE_CARDS = [
     {
@@ -77,6 +200,40 @@ FAKE_CARDS = [
         "never_drawn_win_rate": 0.54,
     },
 ]
+
+
+@pytest.fixture()
+def fake_draft_sets(tmp_path, monkeypatch):
+    """
+    Writes fake parquet files for two sets under SPELLS_DATA_HOME:
+
+    TST (normal set, not in P1P1_MISSING_SETS):
+      3 drafts — all have p1p1 (pick_number=0), only 2 have p1p2 (pick_number=1).
+      Expected num_drafts = 3 (p1p1 count).
+
+    TLA (missing p1p1 set, in P1P1_MISSING_SETS):
+      2 drafts — p1p2 only (pick_number=1), no p1p1 rows.
+      Expected num_drafts = 2 (p1p2 count).
+    """
+    monkeypatch.setenv("SPELLS_DATA_HOME", str(tmp_path))
+    ext = tmp_path / "external"
+
+    tst_rows = [
+        _make_draft_row("TST", "d001", 0, 0, "Aether Sprite"),   # p1p1
+        _make_draft_row("TST", "d001", 0, 1, "Blazing Howl"),    # p1p2
+        _make_draft_row("TST", "d002", 0, 0, "Blazing Howl"),    # p1p1
+        _make_draft_row("TST", "d002", 0, 1, "Crystal Warden"),  # p1p2
+        _make_draft_row("TST", "d003", 0, 0, "Crystal Warden"),  # p1p1 only
+    ]
+    _write_set_parquets(ext, "TST", tst_rows)
+
+    tla_rows = [
+        _make_draft_row("TLA", "d001", 0, 1, "Aether Sprite"),   # p1p2 only
+        _make_draft_row("TLA", "d002", 0, 1, "Blazing Howl"),    # p1p2 only
+    ]
+    _write_set_parquets(ext, "TLA", tla_rows)
+
+    yield tmp_path
 
 
 @pytest.fixture()

--- a/tests/draft_test.py
+++ b/tests/draft_test.py
@@ -1,0 +1,63 @@
+import polars as pl
+import pytest
+
+from spells import summon
+from spells.columns import P1P1_MISSING_SETS
+from tests.conftest import FAKE_CARD_NAMES
+
+
+def test_summon_returns_dataframe(fake_draft_sets):
+    df = summon("TST", ["num_drafts"])
+    assert isinstance(df, pl.DataFrame)
+    assert "num_drafts" in df.columns
+
+
+def test_num_drafts_normal_set_uses_p1p1(fake_draft_sets):
+    # TST has 3 p1p1 rows and 2 p1p2 rows; correct result is 3.
+    df = summon("TST", ["num_drafts"])
+    assert df["num_drafts"].sum() == 3
+
+
+def test_num_drafts_missing_set_uses_p1p2(fake_draft_sets):
+    # TLA has 0 p1p1 rows and 2 p1p2 rows; correct result is 2.
+    df = summon("TLA", ["num_drafts"])
+    assert df["num_drafts"].sum() == 2
+
+
+def test_num_drafts_regression_normal_set_not_p1p2(fake_draft_sets):
+    # If the bug were present (always p1p2), TST would return 2 not 3.
+    df = summon("TST", ["num_drafts"])
+    assert df["num_drafts"].sum() != 2
+
+
+def test_num_drafts_regression_missing_set_not_p1p1(fake_draft_sets):
+    # If fixed to always p1p1, TLA would return 0 (no p1p1 rows exist).
+    df = summon("TLA", ["num_drafts"])
+    assert df["num_drafts"].sum() != 0
+
+
+def test_num_taken_counts_all_picks(fake_draft_sets):
+    # TST fixture has 5 pick rows total.
+    df = summon("TST", ["num_taken"])
+    assert df["num_taken"].sum() == 5
+
+
+def test_summon_group_by_expansion(fake_draft_sets):
+    df = summon(["TST", "TLA"], ["num_drafts"], group_by=["expansion"])
+    tst = df.filter(pl.col("expansion") == "TST")["num_drafts"].sum()
+    tla = df.filter(pl.col("expansion") == "TLA")["num_drafts"].sum()
+    assert tst == 3
+    assert tla == 2
+
+
+def test_filter_spec_pack_num(fake_draft_sets):
+    # All rows are pack 1 (pack_number=0); filtering to pack 2 should give 0.
+    df = summon("TST", ["num_taken"], filter_spec={"pack_num": 2})
+    assert df["num_taken"].sum() == 0
+
+
+def test_p1p1_missing_sets_constant():
+    assert "TLA" in P1P1_MISSING_SETS
+    assert "TMT" in P1P1_MISSING_SETS
+    assert "ECL" in P1P1_MISSING_SETS
+    assert "BLB" not in P1P1_MISSING_SETS


### PR DESCRIPTION
## Summary

- **NUM_DRAFTS fix**: The `num_drafts` column previously always used p1p2 (pick_number=1) as the draft indicator due to an Arena log bug that dropped p1p1 picks in sets TLA, TMT, and ECL. Now branches on `EXPANSION` per-row: sets in `P1P1_MISSING_SETS` keep the p1p2 workaround, all others correctly use p1p1. No lambda or context threading needed — `EXPANSION` is a raw column in every draft row.
- **GIH_WR_STDEV typo**: `ColName.GIH_WR_STDEV` had value `"gh_wr_stdev"` (missing `i`), producing the wrong column name in output DataFrames. Fixed in both `enums.py` and `README.md`.
- **Parquet-path test fixtures**: Adds `fake_draft_sets` fixture and `draft_test.py` with 9 tests covering the num_drafts regression (discriminating between p1p1/p1p2 paths), num_taken, multi-set group_by, and filter_spec. Reusable infrastructure for future parquet-path tests.

## Test plan

- [ ] `pdm run pytest` — 33 tests pass
- [ ] Verify `num_drafts` on TLA sums to p1p2 count, BLB sums to p1p1 count (live check done locally)
- [ ] Confirm `gih_wr_stdev` column name appears correctly in summon output

🤖 Generated with [Claude Code](https://claude.com/claude-code)