### PR TITLE
Add automated PyPI publish via GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install pdm
+        run: pip install pdm
+
+      - name: Build
+        run: pdm build
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BUMP="${1:-patch}"
-if [[ "$BUMP" != "major" && "$BUMP" != "minor" && "$BUMP" != "patch" ]]; then
-    echo "Usage: $0 [major|minor|patch]  (default: patch)"
-    exit 1
-fi
+BUMP="patch"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        major|minor|patch) BUMP="$arg" ;;
+        --dry-run) DRY_RUN=true ;;
+        *) echo "Usage: $0 [major|minor|patch] [--dry-run]"; exit 1 ;;
+    esac
+done
 
 LATEST=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
 if [[ -z "$LATEST" ]]; then
@@ -24,8 +29,19 @@ case "$BUMP" in
 esac
 
 TAG="v${MAJOR}.${MINOR}.${PATCH}"
-echo "Releasing $LATEST -> $TAG"
 
+if $DRY_RUN; then
+    echo "Dry run: $LATEST -> $TAG"
+    echo ""
+    echo "Latest commit:"
+    git log -1 --format="  %h %s (%an, %ar)"
+    echo ""
+    echo "Commits since $LATEST:"
+    git log "${LATEST}..HEAD" --format="  %h %s"
+    exit 0
+fi
+
+echo "Releasing $LATEST -> $TAG"
 git tag "$TAG"
 git push origin "$TAG"
 gh release create "$TAG" --generate-notes --title "$TAG"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -29,9 +29,11 @@ case "$BUMP" in
 esac
 
 TAG="v${MAJOR}.${MINOR}.${PATCH}"
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 if $DRY_RUN; then
     echo "Dry run: $LATEST -> $TAG"
+    echo "Branch: $BRANCH$([ "$BRANCH" != "main" ] && echo " (WARNING: not on main)")"
     echo ""
     echo "Latest commit:"
     git log -1 --format="  %h %s (%an, %ar)"
@@ -39,6 +41,11 @@ if $DRY_RUN; then
     echo "Commits since $LATEST:"
     git log "${LATEST}..HEAD" --format="  %h %s"
     exit 0
+fi
+
+if [[ "$BRANCH" != "main" ]]; then
+    echo "Error: must be on main to release (currently on $BRANCH)"
+    exit 1
 fi
 
 echo "Releasing $LATEST -> $TAG"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,18 +1,30 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -ne 1 ]]; then
-    echo "Usage: $0 <version>  (e.g. $0 0.11.23)"
+BUMP="${1:-patch}"
+if [[ "$BUMP" != "major" && "$BUMP" != "minor" && "$BUMP" != "patch" ]]; then
+    echo "Usage: $0 [major|minor|patch]  (default: patch)"
     exit 1
 fi
 
-VERSION="$1"
-TAG="v${VERSION}"
-
-if git tag | grep -qx "$TAG"; then
-    echo "Tag $TAG already exists"
+LATEST=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+if [[ -z "$LATEST" ]]; then
+    echo "No existing version tags found"
     exit 1
 fi
+
+MAJOR=$(echo "$LATEST" | cut -d. -f1 | tr -d v)
+MINOR=$(echo "$LATEST" | cut -d. -f2)
+PATCH=$(echo "$LATEST" | cut -d. -f3)
+
+case "$BUMP" in
+    major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+    minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+    patch) PATCH=$((PATCH + 1)) ;;
+esac
+
+TAG="v${MAJOR}.${MINOR}.${PATCH}"
+echo "Releasing $LATEST -> $TAG"
 
 git tag "$TAG"
 git push origin "$TAG"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <version>  (e.g. $0 0.11.23)"
+    exit 1
+fi
+
+VERSION="$1"
+TAG="v${VERSION}"
+
+if git tag | grep -qx "$TAG"; then
+    echo "Tag $TAG already exists"
+    exit 1
+fi
+
+git tag "$TAG"
+git push origin "$TAG"
+gh release create "$TAG" --generate-notes --title "$TAG"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/publish.yml` — triggers on GitHub Release publication, builds with pdm, and publishes to PyPI using trusted publishing (OIDC, no stored secrets)
- Adds `scripts/release.sh` — one-command release flow: tags, pushes, and creates the GitHub Release

## Release flow going forward
```bash
git checkout main && git pull
bash scripts/release.sh 0.11.23
```

## Test plan
- [ ] Merge this PR
- [ ] Run `bash scripts/release.sh 0.11.23` from main
- [ ] Verify the Actions tab shows the publish job running
- [ ] Verify `spells-mtg 0.11.23` appears on PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)