### PR TITLE
Add Draft object model: live 17lands factory, view sampling, view isomorphism

### DIFF
--- a/spells/__init__.py
+++ b/spells/__init__.py
@@ -9,7 +9,7 @@ from spells.draft_model import (
     DraftState,
     draft_view_df,
     fetch_draft,
-    view_draft,
+    draft_from_public_data,
 )
 from spells.log import setup_logging
 
@@ -20,7 +20,7 @@ __all__ = [
     "view_select",
     "get_names",
     "fetch_draft",
-    "view_draft",
+    "draft_from_public_data",
     "draft_view_df",
     "Draft",
     "DraftCard",

--- a/spells/__init__.py
+++ b/spells/__init__.py
@@ -3,6 +3,7 @@ import logging
 from spells.columns import ColSpec
 from spells.enums import ColType, ColName
 from spells.draft_data import summon, view_select, get_names
+from spells.draft_model import Draft, DraftCard, DraftState, fetch_draft
 from spells.log import setup_logging
 
 setup_logging()
@@ -11,6 +12,10 @@ __all__ = [
     "summon",
     "view_select",
     "get_names",
+    "fetch_draft",
+    "Draft",
+    "DraftCard",
+    "DraftState",
     "ColSpec",
     "ColType",
     "ColName",

--- a/spells/__init__.py
+++ b/spells/__init__.py
@@ -3,7 +3,14 @@ import logging
 from spells.columns import ColSpec
 from spells.enums import ColType, ColName
 from spells.draft_data import summon, view_select, get_names
-from spells.draft_model import Draft, DraftCard, DraftState, fetch_draft
+from spells.draft_model import (
+    Draft,
+    DraftCard,
+    DraftState,
+    draft_view_df,
+    fetch_draft,
+    view_draft,
+)
 from spells.log import setup_logging
 
 setup_logging()
@@ -13,6 +20,8 @@ __all__ = [
     "view_select",
     "get_names",
     "fetch_draft",
+    "view_draft",
+    "draft_view_df",
     "Draft",
     "DraftCard",
     "DraftState",

--- a/spells/cache.py
+++ b/spells/cache.py
@@ -27,6 +27,7 @@ env = Env.PROD
 class EventType(StrEnum):
     PREMIER = "PremierDraft"
     TRADITIONAL = "TradDraft"
+    PICK_TWO = "PickTwoDraft"
 
 
 class DataDir(StrEnum):

--- a/spells/cache.py
+++ b/spells/cache.py
@@ -34,6 +34,7 @@ class DataDir(StrEnum):
     EXTERNAL = "external"
     RATINGS = "ratings"
     DECK_COLOR = "deck_color"
+    DRAFT = "draft"
 
 
 def spells_print(mode, content):
@@ -146,6 +147,7 @@ def data_dir_path(cache_dir: DataDir) -> str:
         DataDir.EXTERNAL: "External" if is_win else "external",
         DataDir.RATINGS: "Ratings" if is_win else "ratings",
         DataDir.DECK_COLOR: "DeckColor" if is_win else "deck_color",
+        DataDir.DRAFT: "Draft" if is_win else "draft",
     }[cache_dir]
 
     data_dir = os.path.join(data_home(), ext)
@@ -183,6 +185,11 @@ def card_ratings_file_path(
         f"{format}_{user_group}_{deck_color}_{start_date.strftime('%Y-%m-%d')}"
         f"_{end_date.strftime('%Y-%m-%d')}.json"
     )
+
+def draft_file_path(draft_id: str) -> tuple[str, str]:
+    """Completed drafts are immutable, so files are cached indefinitely by id."""
+    return data_dir_path(DataDir.DRAFT), f"{draft_id}.json"
+
 
 def deck_color_file_path(
     set_code: str,

--- a/spells/cache.py
+++ b/spells/cache.py
@@ -187,6 +187,7 @@ def card_ratings_file_path(
         f"_{end_date.strftime('%Y-%m-%d')}.json"
     )
 
+
 def draft_file_path(draft_id: str) -> tuple[str, str]:
     """Completed drafts are immutable, so files are cached indefinitely by id."""
     return data_dir_path(DataDir.DRAFT), f"{draft_id}.json"

--- a/spells/card_data_files.py
+++ b/spells/card_data_files.py
@@ -52,6 +52,19 @@ deck_color_col_defs = {
 }
 
 
+def download_data_file(url: str, target_dir: str, filename: str) -> str:
+    """Download a 17lands data file unless already cached; return the local path."""
+    if not os.path.isdir(target_dir):
+        os.makedirs(target_dir)
+
+    file_path = os.path.join(target_dir, filename)
+
+    if not os.path.isfile(file_path):
+        wget.download(url, out=file_path)
+
+    return file_path
+
+
 def deck_color_df(
     set_code: str,
     format: str = "PremierDraft",
@@ -71,28 +84,19 @@ def deck_color_df(
         end_date,
     )
 
-    if not os.path.isdir(target_dir):
-        os.makedirs(target_dir)
+    user_group_param = (
+        "" if player_cohort == "all" else f"&user_group={player_cohort}"
+    )
 
-    deck_color_file_path = os.path.join(target_dir, filename)
+    url = DECK_COLOR_DATA_TEMPLATE.format(
+        set_code=set_code,
+        format=format,
+        user_group_param=user_group_param,
+        start_date_str=start_date.strftime("%Y-%m-%d"),
+        end_date_str=end_date.strftime("%Y-%m-%d"),
+    )
 
-    if not os.path.isfile(deck_color_file_path):
-        user_group_param = (
-            "" if player_cohort == "all" else f"&user_group={player_cohort}"
-        )
-
-        url = DECK_COLOR_DATA_TEMPLATE.format(
-            set_code=set_code,
-            format=format,
-            user_group_param=user_group_param,
-            start_date_str=start_date.strftime("%Y-%m-%d"),
-            end_date_str=end_date.strftime("%Y-%m-%d"),
-        )
-
-        wget.download(
-            url,
-            out=deck_color_file_path,
-        )
+    deck_color_file_path = download_data_file(url, target_dir, filename)
 
     df = (
         pl.read_json(deck_color_file_path)
@@ -138,32 +142,25 @@ def base_ratings_df(
             end_date,
         )
 
-        if not os.path.isdir(ratings_dir):
-            os.makedirs(ratings_dir)
+        # rate-limit consecutive downloads, but not cache hits
+        if i > 0 and not os.path.isfile(os.path.join(ratings_dir, filename)):
+            sleep(5)
 
-        ratings_file_path = os.path.join(ratings_dir, filename)
+        user_group_param = (
+            "" if player_cohort == "all" else f"&user_group={player_cohort}"
+        )
+        deck_color_param = "" if deck_color == "any" else f"&colors={deck_color}"
 
-        if not os.path.isfile(ratings_file_path):
-            if i > 0:
-                sleep(5)
-            user_group_param = (
-                "" if player_cohort == "all" else f"&user_group={player_cohort}"
-            )
-            deck_color_param = "" if deck_color == "any" else f"&colors={deck_color}"
+        url = RATINGS_TEMPLATE.format(
+            set_code=set_code,
+            format=format,
+            user_group_param=user_group_param,
+            deck_color_param=deck_color_param,
+            start_date_str=start_date.strftime("%Y-%m-%d"),
+            end_date_str=end_date.strftime("%Y-%m-%d"),
+        )
 
-            url = RATINGS_TEMPLATE.format(
-                set_code=set_code,
-                format=format,
-                user_group_param=user_group_param,
-                deck_color_param=deck_color_param,
-                start_date_str=start_date.strftime("%Y-%m-%d"),
-                end_date_str=end_date.strftime("%Y-%m-%d"),
-            )
-
-            wget.download(
-                url,
-                out=ratings_file_path,
-            )
+        ratings_file_path = download_data_file(url, ratings_dir, filename)
 
         concat_list.append(
             pl.read_json(ratings_file_path, infer_schema_length=1000)

--- a/spells/cards.py
+++ b/spells/cards.py
@@ -1,10 +1,13 @@
 import json
+import os
+import re
 import urllib.request
 from enum import StrEnum
 
 import polars as pl
 
-from spells.enums import ColName
+from spells import cache
+from spells.enums import ColName, View
 
 
 class CardAttr(StrEnum):
@@ -126,3 +129,45 @@ def card_df(draft_set_code: str, names: list[str]) -> pl.DataFrame:
             for name in names
         ]
     )
+
+
+def write_card_file(draft_set_code: str, force_download=False) -> int:
+    """
+    Write a parquet file containing basic information about draftable cards,
+    such as rarity, set symbol, color, mana cost, and type. Card names are
+    derived from the local public draft file.
+    """
+    mode = "refresh" if force_download else "add"
+
+    cache.spells_print(
+        mode, "Fetching card data from mtgjson.com and writing card file"
+    )
+    card_filepath = cache.data_file_path(draft_set_code, View.CARD)
+    if os.path.isfile(card_filepath) and not force_download:
+        cache.spells_print(
+            mode,
+            f"File {card_filepath} already exists, use `spells refresh {draft_set_code}` to overwrite",
+        )
+        return 1
+
+    draft_filepath = cache.data_file_path(draft_set_code, View.DRAFT)
+
+    if not os.path.isfile(draft_filepath):
+        cache.spells_print(mode, f"Error: No draft file for set {draft_set_code}")
+        return 1
+
+    columns = pl.scan_parquet(draft_filepath).collect_schema().names()
+
+    pattern = "^pack_card_"
+    names = [
+        re.split(pattern, name)[1]
+        for name in columns
+        if re.search(pattern, name) is not None
+    ]
+
+    df = card_df(draft_set_code, names)
+
+    df.write_parquet(card_filepath)
+
+    cache.spells_print(mode, f"Wrote file {card_filepath}")
+    return 0

--- a/spells/cards.py
+++ b/spells/cards.py
@@ -91,17 +91,22 @@ def _extract_value(set_code: str, name: str, card_dict: dict, field: CardAttr):
 
 def card_df(draft_set_code: str, names: list[str]) -> pl.DataFrame:
     draft_set_json = _fetch_mtg_json(draft_set_code)
-    booster_info = draft_set_json["data"]["booster"]
+    booster_info = draft_set_json["data"].get("booster")
 
-    booster_type = (
-        "play"
-        if "play" in booster_info
-        else "draft"
-        if "draft" in booster_info
-        else list(booster_info.keys())[0]
-    )
-    set_codes = booster_info[booster_type]["sourceSetCodes"]
-    set_codes.reverse()
+    if booster_info:
+        booster_type = (
+            "play"
+            if "play" in booster_info
+            else "draft"
+            if "draft" in booster_info
+            else list(booster_info.keys())[0]
+        )
+        set_codes = booster_info[booster_type]["sourceSetCodes"]
+        set_codes.reverse()
+    else:
+        # Some products (e.g. the OM1 pick-two set) have no booster info in
+        # MTGJSON; their cards come only from their own set list.
+        set_codes = [draft_set_code]
 
     card_data_map = {}
     for set_code in set_codes:
@@ -131,11 +136,16 @@ def card_df(draft_set_code: str, names: list[str]) -> pl.DataFrame:
     )
 
 
-def write_card_file(draft_set_code: str, force_download=False) -> int:
+def write_card_file(
+    draft_set_code: str,
+    event_type: cache.EventType = cache.EventType.PREMIER,
+    force_download=False,
+) -> int:
     """
     Write a parquet file containing basic information about draftable cards,
     such as rarity, set symbol, color, mana cost, and type. Card names are
-    derived from the local public draft file.
+    derived from the local public draft file. The card file is set-level, but
+    the draft file it reads names from is event-type-specific.
     """
     mode = "refresh" if force_download else "add"
 
@@ -150,7 +160,7 @@ def write_card_file(draft_set_code: str, force_download=False) -> int:
         )
         return 1
 
-    draft_filepath = cache.data_file_path(draft_set_code, View.DRAFT)
+    draft_filepath = cache.data_file_path(draft_set_code, View.DRAFT, event_type)
 
     if not os.path.isfile(draft_filepath):
         cache.spells_print(mode, f"Error: No draft file for set {draft_set_code}")

--- a/spells/columns.py
+++ b/spells/columns.py
@@ -232,6 +232,14 @@ _specs: dict[str, ColSpec] = {
         col_type=ColType.NAME_SUM,
         views=[View.DRAFT],
     ),
+    ColName.POOL_COUNT: ColSpec(
+        # Cards in the pool before this pick, summed across pool_ columns. Note
+        # this undercounts multi-pick formats (PickTwoDraft), whose public
+        # pool_ columns only track the `pick` card, not pick_2.
+        col_type=ColType.PICK_SUM,
+        views=[View.DRAFT],
+        expr=lambda names: pl.sum_horizontal([pl.col(f"pool_{name}") for name in names]),
+    ),
     ColName.GAME_TIME: ColSpec(
         col_type=ColType.FILTER_ONLY,
         views=[View.GAME],

--- a/spells/columns.py
+++ b/spells/columns.py
@@ -203,6 +203,10 @@ _specs: dict[str, ColSpec] = {
         col_type=ColType.FILTER_ONLY,
         views=[View.DRAFT],
     ),
+    ColName.PICK_2: ColSpec(
+        col_type=ColType.FILTER_ONLY,
+        views=[View.DRAFT],
+    ),
     ColName.PICK_MAINDECK_RATE: ColSpec(
         col_type=ColType.PICK_SUM,
         views=[View.DRAFT],

--- a/spells/draft_data.py
+++ b/spells/draft_data.py
@@ -626,11 +626,13 @@ def view_select(
     set_code: str,
     view: View,
     columns: list[str],
+    event_type: cache.EventType = cache.EventType.PREMIER,
     filter_spec: dict | None = None,
     extensions: dict[str, ColSpec] | list[dict[str, ColSpec]] | None = None,
     card_context: dict | pl.DataFrame | None = None,
     set_context: dict | pl.DataFrame | None = None,
 ) -> pl.LazyFrame:
+    assert event_type == cache.EventType.PREMIER, "only PremierDraft supported"
     specs = get_specs()
 
     if extensions is not None:

--- a/spells/draft_data.py
+++ b/spells/draft_data.py
@@ -1,5 +1,5 @@
 """
-this is where calculations are performed on the 17Lands public data sets and
+This is where calculations are performed on the 17Lands public data sets and
 aggregate calculations are returned.
 
 Aggregate dataframes containing raw counts are cached in the local file system
@@ -24,6 +24,7 @@ from spells import cache
 import spells.filter as spells_filter
 from spells import manifest
 from spells.columns import ColDef, ColSpec, get_specs
+from spells.cards import write_card_file
 from spells.enums import View, ColName, ColType
 from spells.log import make_verbose
 from spells.card_data_files import base_ratings_df
@@ -33,10 +34,10 @@ DF = TypeVar("DF", pl.LazyFrame, pl.DataFrame)
 @dataclass
 class CardDataFileSpec():
     set_code: str
+    start_date: datetime.date
     format: str = "PremierDraft"
     player_cohort: str = "all"
     deck_colors: str | list[str] = "any"
-    start_date: datetime.date | None = None
     end_date: datetime.date | None = None
 
 
@@ -94,6 +95,8 @@ def _get_card_context(
         columns = list(col_def_map.keys())
 
         fp = cache.data_file_path(set_code, View.CARD)
+        if not os.path.isfile(fp):
+            write_card_file(set_code)
         card_df = pl.read_parquet(fp)
         select_rows = _view_select(
             card_df, frozenset(columns), col_def_map, is_agg_view=False

--- a/spells/draft_data.py
+++ b/spells/draft_data.py
@@ -49,12 +49,14 @@ def _cache_key(args) -> str:
 
 
 @functools.lru_cache(maxsize=None)
-def get_names(set_code: str) -> list[str]:
+def get_names(
+    set_code: str, event_type: cache.EventType = cache.EventType.PREMIER
+) -> list[str]:
     card_fp = cache.data_file_path(set_code, View.CARD)
     card_view = pl.read_parquet(card_fp)
     card_names_set = frozenset(card_view.get_column("name").to_list())
 
-    draft_fp = cache.data_file_path(set_code, View.DRAFT)
+    draft_fp = cache.data_file_path(set_code, View.DRAFT, event_type)
     draft_view = pl.scan_parquet(draft_fp)
     cols = draft_view.collect_schema().names()
 
@@ -76,6 +78,7 @@ def _get_card_context(
     set_context: pl.DataFrame | dict[str, Any] | None,
     card_only: bool = False,
     names: list[str] | None = None,
+    event_type: cache.EventType = cache.EventType.PREMIER,
 ) -> dict[str, dict[str, Any]]:
     card_attr_specs = {
         col: spec
@@ -90,26 +93,27 @@ def _get_card_context(
             set_context=set_context,
             card_context=card_context,
             card_only=True,
+            event_type=event_type,
         )
 
         columns = list(col_def_map.keys())
 
         fp = cache.data_file_path(set_code, View.CARD)
         if not os.path.isfile(fp):
-            write_card_file(set_code)
+            write_card_file(set_code, event_type)
         card_df = pl.read_parquet(fp)
         select_rows = _view_select(
             card_df, frozenset(columns), col_def_map, is_agg_view=False
         ).to_dicts()
 
-        names = get_names(set_code)
+        names = get_names(set_code, event_type)
         loaded_context = {row[ColName.NAME]: row for row in select_rows}
 
         for name in names:
             loaded_context[name] = loaded_context.get(name, {})
     else:
         if names is None:
-            names = get_names(set_code)
+            names = get_names(set_code, event_type)
         loaded_context = {name: {} for name in names}
 
     if card_context is not None:
@@ -292,14 +296,21 @@ def _hydrate_col_defs(
     set_context: pl.DataFrame | dict[str, Any] | None = None,
     card_only: bool = False,
     names: list[str] | None = None,
+    event_type: cache.EventType = cache.EventType.PREMIER,
 ):
     if names is None:
-        names = get_names(set_code)
+        names = get_names(set_code, event_type)
 
     set_context = _get_set_context(set_code, set_context)
 
     card_context = _get_card_context(
-        set_code, specs, card_context, set_context, card_only=card_only, names=names
+        set_code,
+        specs,
+        card_context,
+        set_context,
+        card_only=card_only,
+        names=names,
+        event_type=event_type,
     )
 
     assert len(names) > 0, "there should be names"
@@ -632,7 +643,6 @@ def view_select(
     card_context: dict | pl.DataFrame | None = None,
     set_context: dict | pl.DataFrame | None = None,
 ) -> pl.LazyFrame:
-    assert event_type == cache.EventType.PREMIER, "only PremierDraft supported"
     specs = get_specs()
 
     if extensions is not None:
@@ -641,9 +651,11 @@ def view_select(
         for ext in extensions:
             specs.update(ext)
 
-    col_def_map = _hydrate_col_defs(set_code, specs, card_context, set_context)
+    col_def_map = _hydrate_col_defs(
+        set_code, specs, card_context, set_context, event_type=event_type
+    )
 
-    df_path = cache.data_file_path(set_code, view)
+    df_path = cache.data_file_path(set_code, view, event_type)
     base_view_df = pl.scan_parquet(df_path)
 
     select_cols = frozenset(columns)

--- a/spells/draft_model.py
+++ b/spells/draft_model.py
@@ -159,6 +159,34 @@ def _pick_indices(pack_cards: list[DraftCard], names: list[str]) -> list[int]:
     return indices
 
 
+def _pick_inds(
+    pack_cards: list[DraftCard], picked_names: list[str]
+) -> tuple[int | None, list[int]]:
+    """pick_ind is the single pick; None for pick-two, where picks_ind holds both."""
+    picks_ind = _pick_indices(pack_cards, picked_names)
+    pick_ind = picks_ind[0] if len(picks_ind) == 1 else None
+    return pick_ind, picks_ind
+
+
+def _reconcile_pool(
+    pool_counts: Counter, acc_pool: list[DraftCard], attr_map: dict[str, dict]
+) -> list[DraftCard]:
+    """Accumulated picks, prepended with pool cards picks don't explain.
+
+    Each source's own pool is incomplete in one direction: the view's pool_
+    columns omit pick_2 cards in PickTwoDraft files (kept here via the
+    accumulation), while pure accumulation misses cards seeded into the pool
+    outside of picks, e.g. starting promos (recovered here from pool_counts).
+    """
+    extra = pool_counts - Counter(c.name for c in acc_pool)
+    extra_cards = [
+        card
+        for name, count in extra.items()
+        for card in [_draft_card({ColName.NAME: name}, attr_map)] * count
+    ]
+    return extra_cards + list(acc_pool)
+
+
 def _draft_state(
     pick_data: dict, pool: list[DraftCard], attr_map: dict[str, dict]
 ) -> DraftState:
@@ -169,13 +197,16 @@ def _draft_state(
     pack_cards = [_draft_card(c, attr_map) for c in pick_data["available"]]
 
     picked_names = [c[ColName.NAME] for c in pick_data.get("picks") or []]
-    picks_ind = _pick_indices(pack_cards, picked_names)
+    if not picked_names and (pick := pick_data.get(ColName.PICK)):
+        picked_names = [pick[ColName.NAME]]
+    pick_ind, picks_ind = _pick_inds(pack_cards, picked_names)
 
-    pick = pick_data.get(ColName.PICK)
-    pick_ind = (
-        next((i for i, c in enumerate(pack_cards) if c.name == pick[ColName.NAME]), None)
-        if pick
-        else None
+    # the feed's sections (maindeck/sideboard columns) are its view of the pool
+    section_counts = Counter(
+        c[ColName.NAME]
+        for section in pick_data.get("sections") or []
+        for column in section.get("cards") or []
+        for c in column
     )
 
     return DraftState(
@@ -184,7 +215,7 @@ def _draft_state(
         pack_cards=pack_cards,
         pick_ind=pick_ind,
         picks_ind=picks_ind,
-        pool=pool,
+        pool=_reconcile_pool(section_counts, pool, attr_map),
     )
 
 
@@ -200,11 +231,7 @@ def _draft_from_data(
     ):
         state = _draft_state(pick_data, list(pool), attr_map)
         states.append(state)
-
-        picked_ind = state.picks_ind or (
-            [state.pick_ind] if state.pick_ind is not None else []
-        )
-        pool.extend(state.pack_cards[i] for i in picked_ind)
+        pool.extend(state.pack_cards[i] for i in state.picks_ind)
 
     return Draft(expansion=data[ColName.EXPANSION], draft_id=draft_id, picks=states)
 
@@ -255,11 +282,26 @@ def _cards_from_counts(
     ]
 
 
-def _state_from_row(row: dict, attr_map: dict[str, dict]) -> DraftState:
-    """Build one DraftState from a draft view row (0-indexed -> 1-indexed)."""
+def _state_from_row(
+    row: dict, pool: list[DraftCard], attr_map: dict[str, dict]
+) -> DraftState:
+    """Build one DraftState from a draft view row (0-indexed -> 1-indexed).
+
+    The pool reconciles the caller-accumulated picks against the row's pool_
+    columns; see _reconcile_pool.
+    """
     pack_cards = _cards_from_counts(row, PACK_CARD_PREFIX, attr_map)
-    pick_ind = next(
-        (i for i, c in enumerate(pack_cards) if c.name == row[ColName.PICK]), None
+    picked_names = [
+        name for name in (row.get(ColName.PICK), row.get(ColName.PICK_2)) if name
+    ]
+    pick_ind, picks_ind = _pick_inds(pack_cards, picked_names)
+
+    pool_counts = Counter(
+        {
+            col[len(POOL_PREFIX):]: count
+            for col, count in row.items()
+            if col.startswith(POOL_PREFIX) and count
+        }
     )
 
     return DraftState(
@@ -267,8 +309,8 @@ def _state_from_row(row: dict, attr_map: dict[str, dict]) -> DraftState:
         pick_num=row[ColName.PICK_NUMBER] + 1,
         pack_cards=pack_cards,
         pick_ind=pick_ind,
-        picks_ind=[pick_ind] if pick_ind is not None else [],
-        pool=_cards_from_counts(row, POOL_PREFIX, attr_map),
+        picks_ind=picks_ind,
+        pool=_reconcile_pool(pool_counts, pool, attr_map),
         pick_maindeck_rate=row.get(ColName.PICK_MAINDECK_RATE),
         pick_sideboard_in_rate=row.get(ColName.PICK_SIDEBOARD_IN_RATE),
     )
@@ -278,6 +320,7 @@ def view_draft(
     set_code: str,
     draft_id: str | None = None,
     *,
+    event_type: cache.EventType = cache.EventType.PREMIER,
     filter_expr: pl.Expr | None = None,
     seed: int | None = None,
     card_data: bool = True,
@@ -289,7 +332,7 @@ def view_draft(
     two-pass and streaming: first collect just the matching draft ids, then
     the ~45 rows of the chosen draft -- the full view is never materialized.
     """
-    lf = pl.scan_parquet(cache.data_file_path(set_code, View.DRAFT))
+    lf = pl.scan_parquet(cache.data_file_path(set_code, View.DRAFT, event_type))
 
     if draft_id is None:
         id_lf = lf if filter_expr is None else lf.filter(filter_expr)
@@ -317,10 +360,17 @@ def view_draft(
         )
         attr_map = _card_attr_map(set_code, names)
 
+    states = []
+    pool: list[DraftCard] = []
+    for row in rows:
+        state = _state_from_row(row, list(pool), attr_map)
+        states.append(state)
+        pool.extend(state.pack_cards[i] for i in state.picks_ind)
+
     return Draft(
         expansion=rows[0][ColName.EXPANSION],
         draft_id=draft_id,
-        picks=[_state_from_row(row, attr_map) for row in rows],
+        picks=states,
         **{field: rows[0].get(field) for field in DRAFT_META_FIELDS},
     )
 
@@ -342,6 +392,7 @@ def draft_view_df(draft: Draft) -> pl.DataFrame:
         names = sorted(
             {c.name for s in draft.picks for c in [*s.pack_cards, *s.pool]}
         )
+        has_pick_2 = any(len(s.picks_ind) > 1 for s in draft.picks)
         meta_schema = {
             ColName.EXPANSION: pl.String,
             ColName.EVENT_TYPE: pl.String,
@@ -353,6 +404,7 @@ def draft_view_df(draft: Draft) -> pl.DataFrame:
             ColName.PACK_NUMBER: pl.Int8,
             ColName.PICK_NUMBER: pl.Int8,
             ColName.PICK: pl.String,
+            **({ColName.PICK_2: pl.String} if has_pick_2 else {}),
             ColName.PICK_MAINDECK_RATE: pl.Float64,
             ColName.PICK_SIDEBOARD_IN_RATE: pl.Float64,
             ColName.USER_N_GAMES_BUCKET: pl.Int16,
@@ -370,16 +422,14 @@ def draft_view_df(draft: Draft) -> pl.DataFrame:
     for state in draft.picks:
         pack_counts = Counter(c.name for c in state.pack_cards)
         pool_counts = Counter(c.name for c in state.pool)
+        picked = [state.pack_cards[i].name for i in state.picks_ind]
         row = {
             ColName.EXPANSION: draft.expansion,
             ColName.DRAFT_ID: draft.draft_id,
             ColName.PACK_NUMBER: state.pack_num - 1,
             ColName.PICK_NUMBER: state.pick_num - 1,
-            ColName.PICK: (
-                state.pack_cards[state.pick_ind].name
-                if state.pick_ind is not None
-                else None
-            ),
+            ColName.PICK: picked[0] if picked else None,
+            ColName.PICK_2: picked[1] if len(picked) > 1 else None,
             ColName.PICK_MAINDECK_RATE: state.pick_maindeck_rate,
             ColName.PICK_SIDEBOARD_IN_RATE: state.pick_sideboard_in_rate,
             **{field: getattr(draft, field) for field in DRAFT_META_FIELDS},

--- a/spells/draft_model.py
+++ b/spells/draft_model.py
@@ -1,0 +1,115 @@
+"""Object model for individual drafts.
+
+A `Draft` is a succession of `DraftState`s, one per pack/pick index. The
+chosen card is identified by index into `pack_cards` (`pick_ind`, or
+`picks_ind` for pick-two formats), and `pool` accumulates prior picks.
+
+Cards carry identity only (no metrics); annotate with metric data by joining
+on name downstream.
+"""
+
+import json
+from dataclasses import dataclass
+
+from spells import cache
+from spells.card_data_files import download_data_file
+
+DRAFT_DATA_TEMPLATE = "https://www.17lands.com/data/draft?draft_id={draft_id}"
+
+
+@dataclass
+class DraftCard:
+    name: str
+    set_code: str | None = None  # the card's own printing set; not in the draft feed
+    image_url: str = ""
+
+
+@dataclass
+class DraftState:
+    pack_num: int  # 1-indexed, as ColName.PACK_NUM
+    pick_num: int  # 1-indexed, as ColName.PICK_NUM
+    pack_cards: list[DraftCard]
+    pick_ind: int | None
+    picks_ind: list[int]
+    pool: list[DraftCard]
+
+
+@dataclass
+class Draft:
+    expansion: str
+    draft_id: str
+    picks: list[DraftState]
+
+
+def _draft_card(card: dict) -> DraftCard:
+    return DraftCard(name=card["name"], image_url=card.get("image_url", ""))
+
+
+def _pick_indices(pack_cards: list[DraftCard], names: list[str]) -> list[int]:
+    """Indices of picked cards within the pack; duplicate names consume distinct indices."""
+    used: set[int] = set()
+    indices = []
+    for name in names:
+        ind = next(
+            (i for i, c in enumerate(pack_cards) if c.name == name and i not in used),
+            None,
+        )
+        if ind is not None:
+            used.add(ind)
+            indices.append(ind)
+    return indices
+
+
+def _draft_state(pick_data: dict, pool: list[DraftCard]) -> DraftState:
+    """Build one DraftState from a 17lands pick object.
+
+    17lands pack/pick numbers are 0-indexed; the model is 1-indexed.
+    """
+    pack_cards = [_draft_card(c) for c in pick_data["available"]]
+
+    picked_names = [c["name"] for c in pick_data.get("picks") or []]
+    picks_ind = _pick_indices(pack_cards, picked_names)
+
+    pick = pick_data.get("pick")
+    pick_ind = (
+        next((i for i, c in enumerate(pack_cards) if c.name == pick["name"]), None)
+        if pick
+        else None
+    )
+
+    return DraftState(
+        pack_num=pick_data["pack_number"] + 1,
+        pick_num=pick_data["pick_number"] + 1,
+        pack_cards=pack_cards,
+        pick_ind=pick_ind,
+        picks_ind=picks_ind,
+        pool=pool,
+    )
+
+
+def _draft_from_data(draft_id: str, data: dict) -> Draft:
+    states = []
+    pool: list[DraftCard] = []
+    for pick_data in sorted(
+        data["picks"], key=lambda p: (p["pack_number"], p["pick_number"])
+    ):
+        state = _draft_state(pick_data, list(pool))
+        states.append(state)
+
+        picked_ind = state.picks_ind or (
+            [state.pick_ind] if state.pick_ind is not None else []
+        )
+        pool.extend(state.pack_cards[i] for i in picked_ind)
+
+    return Draft(expansion=data["expansion"], draft_id=draft_id, picks=states)
+
+
+def fetch_draft(draft_id: str) -> Draft:
+    """Build a Draft from the 17lands live draft endpoint, cached locally by id."""
+    target_dir, filename = cache.draft_file_path(draft_id)
+    file_path = download_data_file(
+        DRAFT_DATA_TEMPLATE.format(draft_id=draft_id), target_dir, filename
+    )
+    with open(file_path, encoding="utf-8") as f:
+        data = json.load(f)
+    return _draft_from_data(draft_id, data)

--- a/spells/draft_model.py
+++ b/spells/draft_model.py
@@ -4,15 +4,21 @@ A `Draft` is a succession of `DraftState`s, one per pack/pick index. The
 chosen card is identified by index into `pack_cards` (`pick_ind`, or
 `picks_ind` for pick-two formats), and `pool` accumulates prior picks.
 
-Cards carry identity only (no metrics); annotate with metric data by joining
-on name downstream.
+Cards carry identity and static card attributes (joined from MTGJSON via the
+spells card file), but no metrics; annotate with metric data by joining on
+name downstream.
 """
 
 import json
+import os
 from dataclasses import dataclass
+
+import polars as pl
 
 from spells import cache
 from spells.card_data_files import download_data_file
+from spells.cards import card_df, write_card_file
+from spells.enums import ColName, View
 
 DRAFT_DATA_TEMPLATE = "https://www.17lands.com/data/draft?draft_id={draft_id}"
 
@@ -20,8 +26,21 @@ DRAFT_DATA_TEMPLATE = "https://www.17lands.com/data/draft?draft_id={draft_id}"
 @dataclass
 class DraftCard:
     name: str
-    set_code: str | None = None  # the card's own printing set; not in the draft feed
+    set_code: str | None = None  # the card's own printing set, from MTGJSON
     image_url: str = ""
+    color: str | None = None
+    rarity: str | None = None
+    color_identity: str | None = None
+    card_type: str | None = None
+    subtype: str | None = None
+    mana_value: float | None = None
+    mana_cost: str | None = None
+    power: str | None = None
+    toughness: str | None = None
+    is_bonus_sheet: bool | None = None
+    is_dfc: bool | None = None
+    oracle_text: str | None = None
+    scryfall_id: str | None = None
 
 
 @dataclass
@@ -29,7 +48,7 @@ class DraftState:
     pack_num: int  # 1-indexed, as ColName.PACK_NUM
     pick_num: int  # 1-indexed, as ColName.PICK_NUM
     pack_cards: list[DraftCard]
-    pick_ind: int | None
+    pick_ind: int | None  # None for pick two draft, use picks_ind
     picks_ind: list[int]
     pool: list[DraftCard]
 
@@ -41,8 +60,59 @@ class Draft:
     picks: list[DraftState]
 
 
-def _draft_card(card: dict) -> DraftCard:
-    return DraftCard(name=card["name"], image_url=card.get("image_url", ""))
+# DraftCard fields populated from the card file rather than the draft feed
+CARD_ATTR_FIELDS = (
+    ColName.SET_CODE,
+    ColName.COLOR,
+    ColName.RARITY,
+    ColName.COLOR_IDENTITY,
+    ColName.CARD_TYPE,
+    ColName.SUBTYPE,
+    ColName.MANA_VALUE,
+    ColName.MANA_COST,
+    ColName.POWER,
+    ColName.TOUGHNESS,
+    ColName.IS_BONUS_SHEET,
+    ColName.IS_DFC,
+    ColName.ORACLE_TEXT,
+    ColName.SCRYFALL_ID,
+)
+
+
+def _card_attr_map(expansion: str, names: list[str]) -> dict[str, dict]:
+    """name -> card attribute row, preferring the local spells card file.
+
+    When no card file exists, write one if the public draft file is present;
+    otherwise fall back to a live MTGJSON fetch for the draft's own names.
+    Returns an empty map when card data can't be sourced (e.g. cubes, which
+    are not MTGJSON sets).
+    """
+    file_path = cache.data_file_path(expansion, View.CARD)
+
+    if not os.path.isfile(file_path) and os.path.isfile(
+        cache.data_file_path(expansion, View.DRAFT)
+    ):
+        write_card_file(expansion)
+
+    if os.path.isfile(file_path):
+        df = pl.read_parquet(file_path)
+    else:
+        try:
+            df = card_df(expansion, names)
+        except Exception:
+            cache.spells_print("draft", f"No card data available for {expansion}")
+            return {}
+
+    return {row[ColName.NAME]: row for row in df.to_dicts()}
+
+
+def _draft_card(card: dict, attr_map: dict[str, dict]) -> DraftCard:
+    attrs = attr_map.get(card["name"], {})
+    return DraftCard(
+        name=card["name"],
+        image_url=card.get("image_url", "") or attrs.get(ColName.IMAGE_URL, ""),
+        **{field: attrs.get(field) for field in CARD_ATTR_FIELDS},
+    )
 
 
 def _pick_indices(pack_cards: list[DraftCard], names: list[str]) -> list[int]:
@@ -60,12 +130,14 @@ def _pick_indices(pack_cards: list[DraftCard], names: list[str]) -> list[int]:
     return indices
 
 
-def _draft_state(pick_data: dict, pool: list[DraftCard]) -> DraftState:
+def _draft_state(
+    pick_data: dict, pool: list[DraftCard], attr_map: dict[str, dict]
+) -> DraftState:
     """Build one DraftState from a 17lands pick object.
 
     17lands pack/pick numbers are 0-indexed; the model is 1-indexed.
     """
-    pack_cards = [_draft_card(c) for c in pick_data["available"]]
+    pack_cards = [_draft_card(c, attr_map) for c in pick_data["available"]]
 
     picked_names = [c["name"] for c in pick_data.get("picks") or []]
     picks_ind = _pick_indices(pack_cards, picked_names)
@@ -87,13 +159,16 @@ def _draft_state(pick_data: dict, pool: list[DraftCard]) -> DraftState:
     )
 
 
-def _draft_from_data(draft_id: str, data: dict) -> Draft:
+def _draft_from_data(
+    draft_id: str, data: dict, attr_map: dict[str, dict] | None = None
+) -> Draft:
+    attr_map = attr_map or {}
     states = []
     pool: list[DraftCard] = []
     for pick_data in sorted(
         data["picks"], key=lambda p: (p["pack_number"], p["pick_number"])
     ):
-        state = _draft_state(pick_data, list(pool))
+        state = _draft_state(pick_data, list(pool), attr_map)
         states.append(state)
 
         picked_ind = state.picks_ind or (
@@ -104,12 +179,24 @@ def _draft_from_data(draft_id: str, data: dict) -> Draft:
     return Draft(expansion=data["expansion"], draft_id=draft_id, picks=states)
 
 
-def fetch_draft(draft_id: str) -> Draft:
-    """Build a Draft from the 17lands live draft endpoint, cached locally by id."""
+def fetch_draft(draft_id: str, card_data: bool = True) -> Draft:
+    """Build a Draft from the 17lands live draft endpoint, cached locally by id.
+
+    Card attributes are joined from MTGJSON data (via the spells card file)
+    unless card_data=False.
+    """
     target_dir, filename = cache.draft_file_path(draft_id)
     file_path = download_data_file(
         DRAFT_DATA_TEMPLATE.format(draft_id=draft_id), target_dir, filename
     )
     with open(file_path, encoding="utf-8") as f:
         data = json.load(f)
-    return _draft_from_data(draft_id, data)
+
+    attr_map = None
+    if card_data:
+        names = sorted(
+            {c["name"] for p in data["picks"] for c in p["available"]}
+        )
+        attr_map = _card_attr_map(data["expansion"], names)
+
+    return _draft_from_data(draft_id, data, attr_map)

--- a/spells/draft_model.py
+++ b/spells/draft_model.py
@@ -107,10 +107,10 @@ def _card_attr_map(expansion: str, names: list[str]) -> dict[str, dict]:
 
 
 def _draft_card(card: dict, attr_map: dict[str, dict]) -> DraftCard:
-    attrs = attr_map.get(card["name"], {})
+    attrs = attr_map.get(card[ColName.NAME], {})
     return DraftCard(
-        name=card["name"],
-        image_url=card.get("image_url", "") or attrs.get(ColName.IMAGE_URL, ""),
+        name=card[ColName.NAME],
+        image_url=card.get(ColName.IMAGE_URL, "") or attrs.get(ColName.IMAGE_URL, ""),
         **{field: attrs.get(field) for field in CARD_ATTR_FIELDS},
     )
 
@@ -139,19 +139,19 @@ def _draft_state(
     """
     pack_cards = [_draft_card(c, attr_map) for c in pick_data["available"]]
 
-    picked_names = [c["name"] for c in pick_data.get("picks") or []]
+    picked_names = [c[ColName.NAME] for c in pick_data.get("picks") or []]
     picks_ind = _pick_indices(pack_cards, picked_names)
 
-    pick = pick_data.get("pick")
+    pick = pick_data.get(ColName.PICK)
     pick_ind = (
-        next((i for i, c in enumerate(pack_cards) if c.name == pick["name"]), None)
+        next((i for i, c in enumerate(pack_cards) if c.name == pick[ColName.NAME]), None)
         if pick
         else None
     )
 
     return DraftState(
-        pack_num=pick_data["pack_number"] + 1,
-        pick_num=pick_data["pick_number"] + 1,
+        pack_num=pick_data[ColName.PACK_NUMBER] + 1,
+        pick_num=pick_data[ColName.PICK_NUMBER] + 1,
         pack_cards=pack_cards,
         pick_ind=pick_ind,
         picks_ind=picks_ind,
@@ -166,7 +166,8 @@ def _draft_from_data(
     states = []
     pool: list[DraftCard] = []
     for pick_data in sorted(
-        data["picks"], key=lambda p: (p["pack_number"], p["pick_number"])
+        data["picks"],
+        key=lambda p: (p[ColName.PACK_NUMBER], p[ColName.PICK_NUMBER]),
     ):
         state = _draft_state(pick_data, list(pool), attr_map)
         states.append(state)
@@ -176,7 +177,7 @@ def _draft_from_data(
         )
         pool.extend(state.pack_cards[i] for i in picked_ind)
 
-    return Draft(expansion=data["expansion"], draft_id=draft_id, picks=states)
+    return Draft(expansion=data[ColName.EXPANSION], draft_id=draft_id, picks=states)
 
 
 def fetch_draft(draft_id: str, card_data: bool = True) -> Draft:
@@ -195,8 +196,8 @@ def fetch_draft(draft_id: str, card_data: bool = True) -> Draft:
     attr_map = None
     if card_data:
         names = sorted(
-            {c["name"] for p in data["picks"] for c in p["available"]}
+            {c[ColName.NAME] for p in data["picks"] for c in p["available"]}
         )
-        attr_map = _card_attr_map(data["expansion"], names)
+        attr_map = _card_attr_map(data[ColName.EXPANSION], names)
 
     return _draft_from_data(draft_id, data, attr_map)

--- a/spells/draft_model.py
+++ b/spells/draft_model.py
@@ -11,6 +11,9 @@ name downstream.
 
 import json
 import os
+import random
+import warnings
+from collections import Counter
 from dataclasses import dataclass
 
 import polars as pl
@@ -21,6 +24,9 @@ from spells.cards import card_df, write_card_file
 from spells.enums import ColName, View
 
 DRAFT_DATA_TEMPLATE = "https://www.17lands.com/data/draft?draft_id={draft_id}"
+
+PACK_CARD_PREFIX = f"{ColName.PACK_CARD}_"
+POOL_PREFIX = f"{ColName.POOL}_"
 
 
 @dataclass
@@ -51,6 +57,9 @@ class DraftState:
     pick_ind: int | None  # None for pick two draft, use picks_ind
     picks_ind: list[int]
     pool: list[DraftCard]
+    # per-pick annotations from the draft view; None on the live feed path
+    pick_maindeck_rate: float | None = None
+    pick_sideboard_in_rate: float | None = None
 
 
 @dataclass
@@ -58,6 +67,26 @@ class Draft:
     expansion: str
     draft_id: str
     picks: list[DraftState]
+    # draft-level metadata from the draft view; None on the live feed path
+    event_type: str | None = None
+    draft_time: str | None = None
+    rank: str | None = None
+    event_match_wins: int | None = None
+    event_match_losses: int | None = None
+    user_n_games_bucket: int | None = None
+    user_game_win_rate_bucket: float | None = None
+
+
+# Draft fields read from / written to the draft view by column name
+DRAFT_META_FIELDS = (
+    ColName.EVENT_TYPE,
+    ColName.DRAFT_TIME,
+    ColName.RANK,
+    ColName.EVENT_MATCH_WINS,
+    ColName.EVENT_MATCH_LOSSES,
+    ColName.USER_N_GAMES_BUCKET,
+    ColName.USER_GAME_WIN_RATE_BUCKET,
+)
 
 
 # DraftCard fields populated from the card file rather than the draft feed
@@ -201,3 +230,172 @@ def fetch_draft(draft_id: str, card_data: bool = True) -> Draft:
         attr_map = _card_attr_map(data[ColName.EXPANSION], names)
 
     return _draft_from_data(draft_id, data, attr_map)
+
+
+def _collect(lf: pl.LazyFrame) -> pl.DataFrame:
+    """Collect with the streaming engine so large draft views stay off-heap."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            "The old streaming engine is being deprecated",
+            DeprecationWarning,
+        )
+        return lf.collect(streaming=True)
+
+
+def _cards_from_counts(
+    row: dict, prefix: str, attr_map: dict[str, dict]
+) -> list[DraftCard]:
+    """Expand a view row's prefixed count columns into cards, with multiplicity."""
+    return [
+        card
+        for col, count in row.items()
+        if col.startswith(prefix) and count
+        for card in [_draft_card({ColName.NAME: col[len(prefix):]}, attr_map)] * count
+    ]
+
+
+def _state_from_row(row: dict, attr_map: dict[str, dict]) -> DraftState:
+    """Build one DraftState from a draft view row (0-indexed -> 1-indexed)."""
+    pack_cards = _cards_from_counts(row, PACK_CARD_PREFIX, attr_map)
+    pick_ind = next(
+        (i for i, c in enumerate(pack_cards) if c.name == row[ColName.PICK]), None
+    )
+
+    return DraftState(
+        pack_num=row[ColName.PACK_NUMBER] + 1,
+        pick_num=row[ColName.PICK_NUMBER] + 1,
+        pack_cards=pack_cards,
+        pick_ind=pick_ind,
+        picks_ind=[pick_ind] if pick_ind is not None else [],
+        pool=_cards_from_counts(row, POOL_PREFIX, attr_map),
+        pick_maindeck_rate=row.get(ColName.PICK_MAINDECK_RATE),
+        pick_sideboard_in_rate=row.get(ColName.PICK_SIDEBOARD_IN_RATE),
+    )
+
+
+def view_draft(
+    set_code: str,
+    draft_id: str | None = None,
+    *,
+    filter_expr: pl.Expr | None = None,
+    seed: int | None = None,
+    card_data: bool = True,
+) -> Draft:
+    """Build a Draft from the local draft view (public 17lands dataset).
+
+    Look up by draft_id, or sample a random draft from the rows matching
+    filter_expr (a polars expression over the raw view columns). Sampling is
+    two-pass and streaming: first collect just the matching draft ids, then
+    the ~45 rows of the chosen draft -- the full view is never materialized.
+    """
+    lf = pl.scan_parquet(cache.data_file_path(set_code, View.DRAFT))
+
+    if draft_id is None:
+        id_lf = lf if filter_expr is None else lf.filter(filter_expr)
+        ids = _collect(id_lf.select(ColName.DRAFT_ID).unique().sort(ColName.DRAFT_ID))[
+            ColName.DRAFT_ID
+        ]
+        if len(ids) == 0:
+            raise ValueError(f"no drafts match filter for {set_code}")
+        draft_id = ids[random.Random(seed).randrange(len(ids))]
+
+    rows = (
+        _collect(lf.filter(pl.col(ColName.DRAFT_ID) == draft_id))
+        .sort(ColName.PACK_NUMBER, ColName.PICK_NUMBER)
+        .to_dicts()
+    )
+    if not rows:
+        raise ValueError(f"draft {draft_id} not found in {set_code} draft view")
+
+    attr_map = {}
+    if card_data:
+        names = sorted(
+            col[len(PACK_CARD_PREFIX):]
+            for col in rows[0]
+            if col.startswith(PACK_CARD_PREFIX)
+        )
+        attr_map = _card_attr_map(set_code, names)
+
+    return Draft(
+        expansion=rows[0][ColName.EXPANSION],
+        draft_id=draft_id,
+        picks=[_state_from_row(row, attr_map) for row in rows],
+        **{field: rows[0].get(field) for field in DRAFT_META_FIELDS},
+    )
+
+
+def draft_view_df(draft: Draft) -> pl.DataFrame:
+    """Render a Draft as a dataframe matching the draft view schema.
+
+    One row per DraftState, with the model's 1-indexed numbers written back
+    as the view's 0-indexed ones. When the local draft view exists for the
+    expansion its exact schema (column order and dtypes) is used; otherwise
+    a conforming schema is constructed from the draft's own card names.
+    Fields the model doesn't carry come out null; the view's pool ordering
+    (counts) loses the model's pick-order pool.
+    """
+    file_path = cache.data_file_path(draft.expansion, View.DRAFT)
+    if os.path.isfile(file_path):
+        target_schema = pl.scan_parquet(file_path).collect_schema()
+    else:
+        names = sorted(
+            {c.name for s in draft.picks for c in [*s.pack_cards, *s.pool]}
+        )
+        meta_schema = {
+            ColName.EXPANSION: pl.String,
+            ColName.EVENT_TYPE: pl.String,
+            ColName.DRAFT_ID: pl.String,
+            ColName.DRAFT_TIME: pl.String,
+            ColName.RANK: pl.String,
+            ColName.EVENT_MATCH_WINS: pl.Int8,
+            ColName.EVENT_MATCH_LOSSES: pl.Int8,
+            ColName.PACK_NUMBER: pl.Int8,
+            ColName.PICK_NUMBER: pl.Int8,
+            ColName.PICK: pl.String,
+            ColName.PICK_MAINDECK_RATE: pl.Float64,
+            ColName.PICK_SIDEBOARD_IN_RATE: pl.Float64,
+            ColName.USER_N_GAMES_BUCKET: pl.Int16,
+            ColName.USER_GAME_WIN_RATE_BUCKET: pl.Float64,
+        }
+        target_schema = pl.Schema(
+            {
+                **{str(k): v for k, v in meta_schema.items()},
+                **{f"{POOL_PREFIX}{n}": pl.Int8 for n in names},
+                **{f"{PACK_CARD_PREFIX}{n}": pl.Int8 for n in names},
+            }
+        )
+
+    rows = []
+    for state in draft.picks:
+        pack_counts = Counter(c.name for c in state.pack_cards)
+        pool_counts = Counter(c.name for c in state.pool)
+        row = {
+            ColName.EXPANSION: draft.expansion,
+            ColName.DRAFT_ID: draft.draft_id,
+            ColName.PACK_NUMBER: state.pack_num - 1,
+            ColName.PICK_NUMBER: state.pick_num - 1,
+            ColName.PICK: (
+                state.pack_cards[state.pick_ind].name
+                if state.pick_ind is not None
+                else None
+            ),
+            ColName.PICK_MAINDECK_RATE: state.pick_maindeck_rate,
+            ColName.PICK_SIDEBOARD_IN_RATE: state.pick_sideboard_in_rate,
+            **{field: getattr(draft, field) for field in DRAFT_META_FIELDS},
+        }
+        rows.append(
+            {
+                col: row.get(
+                    col,
+                    pack_counts.get(col[len(PACK_CARD_PREFIX):], 0)
+                    if col.startswith(PACK_CARD_PREFIX)
+                    else pool_counts.get(col[len(POOL_PREFIX):], 0)
+                    if col.startswith(POOL_PREFIX)
+                    else None,
+                )
+                for col in target_schema.names()
+            }
+        )
+
+    return pl.DataFrame(rows, schema=target_schema)

--- a/spells/draft_model.py
+++ b/spells/draft_model.py
@@ -15,6 +15,7 @@ import random
 import warnings
 from collections import Counter
 from dataclasses import dataclass
+import itertools
 
 import polars as pl
 
@@ -185,6 +186,46 @@ def _reconcile_pool(
         for card in [_draft_card({ColName.NAME: name}, attr_map)] * count
     ]
     return extra_cards + list(acc_pool)
+
+
+def _gap_states(
+    pack_num_0: int,
+    first_pick_0: int,
+    pool_counts: Counter,
+    acc_pool: list[DraftCard],
+    attr_map: dict[str, dict],
+) -> list[DraftState]:
+    """Synthesize DraftStates for pick rows absent from the draft view.
+
+    A known Arena client bug caused picks to go unrecorded in several sets;
+    the 17lands parquet strips those rows entirely while the live API returns
+    them with available=[picked_card]. The picked card is inferred from the
+    pool_ columns at the first recorded row minus accumulated pool.
+    """
+    extra = pool_counts - Counter(c.name for c in acc_pool)
+    inferred = [
+        _draft_card({ColName.NAME: name}, attr_map)
+        for name, count in extra.items()
+        for _ in range(count)
+    ]
+    states: list[DraftState] = []
+    local_pool = list(acc_pool)
+    for i in range(first_pick_0):
+        picked = inferred[i] if i < len(inferred) else None
+        pack_cards = [picked] if picked else []
+        states.append(
+            DraftState(
+                pack_num=pack_num_0 + 1,
+                pick_num=i + 1,
+                pack_cards=pack_cards,
+                pick_ind=0 if picked else None,
+                picks_ind=[0] if picked else [],
+                pool=list(local_pool),
+            )
+        )
+        if picked:
+            local_pool.append(picked)
+    return states
 
 
 def _draft_state(
@@ -362,10 +403,24 @@ def view_draft(
 
     states = []
     pool: list[DraftCard] = []
-    for row in rows:
-        state = _state_from_row(row, list(pool), attr_map)
-        states.append(state)
-        pool.extend(state.pack_cards[i] for i in state.picks_ind)
+    for pack_num_0, pack_rows in itertools.groupby(rows, key=lambda r: r[ColName.PACK_NUMBER]):
+        pack_rows = list(pack_rows)
+        first_pick = pack_rows[0][ColName.PICK_NUMBER]
+        if first_pick > 0:
+            pool_counts = Counter(
+                {
+                    col[len(POOL_PREFIX):]: count
+                    for col, count in pack_rows[0].items()
+                    if col.startswith(POOL_PREFIX) and count
+                }
+            )
+            for s in _gap_states(pack_num_0, first_pick, pool_counts, list(pool), attr_map):
+                states.append(s)
+                pool.extend(s.pack_cards[i] for i in s.picks_ind)
+        for row in pack_rows:
+            state = _state_from_row(row, list(pool), attr_map)
+            states.append(state)
+            pool.extend(state.pack_cards[i] for i in state.picks_ind)
 
     return Draft(
         expansion=rows[0][ColName.EXPANSION],

--- a/spells/draft_model.py
+++ b/spells/draft_model.py
@@ -15,6 +15,7 @@ import random
 import warnings
 from collections import Counter
 from dataclasses import dataclass
+from typing import Any
 import itertools
 
 import polars as pl
@@ -22,6 +23,7 @@ import polars as pl
 from spells import cache
 from spells.card_data_files import download_data_file
 from spells.cards import card_df, write_card_file
+from spells.draft_data import view_select
 from spells.enums import ColName, View
 
 DRAFT_DATA_TEMPLATE = "https://www.17lands.com/data/draft?draft_id={draft_id}"
@@ -357,32 +359,51 @@ def _state_from_row(
     )
 
 
-def view_draft(
+def draft_from_public_data(
     set_code: str,
     draft_id: str | None = None,
     *,
     event_type: cache.EventType = cache.EventType.PREMIER,
-    filter_expr: pl.Expr | None = None,
+    filter_spec: dict[str, Any] | None = None,
     seed: int | None = None,
     card_data: bool = True,
 ) -> Draft:
     """Build a Draft from the local draft view (public 17lands dataset).
 
     Look up by draft_id, or sample a random draft from the rows matching
-    filter_expr (a polars expression over the raw view columns). Sampling is
+    filter_spec (a filter DSL dict over the raw view columns). Sampling is
     two-pass and streaming: first collect just the matching draft ids, then
     the ~45 rows of the chosen draft -- the full view is never materialized.
     """
-    lf = pl.scan_parquet(cache.data_file_path(set_code, View.DRAFT, event_type))
+    lf = view_select(
+        set_code=set_code,
+        view=View.DRAFT,
+        columns=[
+            ColName.EXPANSION,
+            ColName.DRAFT_ID,
+            ColName.PACK_NUMBER,
+            ColName.PICK_NUMBER,
+            ColName.PACK_CARD,
+            ColName.PICK,
+            *([ColName.PICK_2] if event_type == cache.EventType.PICK_TWO else []),
+            ColName.POOL,
+            *DRAFT_META_FIELDS,
+            ColName.PICK_MAINDECK_RATE,
+            ColName.PICK_SIDEBOARD_IN_RATE,
+        ],
+        event_type=event_type,
+        filter_spec=filter_spec,
+    )
 
     if draft_id is None:
-        id_lf = lf if filter_expr is None else lf.filter(filter_expr)
-        ids = _collect(id_lf.select(ColName.DRAFT_ID).unique().sort(ColName.DRAFT_ID))[
+        ids = _collect(lf.select(ColName.DRAFT_ID).unique().sort(ColName.DRAFT_ID))[
             ColName.DRAFT_ID
         ]
         if len(ids) == 0:
             raise ValueError(f"no drafts match filter for {set_code}")
         draft_id = ids[random.Random(seed).randrange(len(ids))]
+
+    assert isinstance(draft_id, str)
 
     rows = (
         _collect(lf.filter(pl.col(ColName.DRAFT_ID) == draft_id))

--- a/spells/draft_model.py
+++ b/spells/draft_model.py
@@ -499,7 +499,7 @@ def draft_view_df(draft: Draft) -> pl.DataFrame:
         pack_counts = Counter(c.name for c in state.pack_cards)
         pool_counts = Counter(c.name for c in state.pool)
         picked = [state.pack_cards[i].name for i in state.picks_ind]
-        row = {
+        row: dict[str, Any] = {
             ColName.EXPANSION: draft.expansion,
             ColName.DRAFT_ID: draft.draft_id,
             ColName.PACK_NUMBER: state.pack_num - 1,

--- a/spells/enums.py
+++ b/spells/enums.py
@@ -65,6 +65,7 @@ class ColName(StrEnum):
     NUM_TAKEN = "num_taken"
     NUM_DRAFTS = "num_drafts"
     PICK = "pick"
+    PICK_2 = "pick_2"  # PickTwoDraft only
     PICK_MAINDECK_RATE = "pick_maindeck_rate"
     PICK_SIDEBOARD_IN_RATE = "pick_sideboard_in_rate"
     PACK_CARD = "pack_card"

--- a/spells/enums.py
+++ b/spells/enums.py
@@ -72,6 +72,7 @@ class ColName(StrEnum):
     LAST_SEEN = "last_seen"
     NUM_SEEN = "num_seen"
     POOL = "pool"
+    POOL_COUNT = "pool_count"
     # game
     GAME_TIME = "game_time"
     GAME_DATE = "game_date"

--- a/spells/external.py
+++ b/spells/external.py
@@ -47,7 +47,7 @@ def cli() -> int:
     data_dir = cache.data_home()
     cache.spells_print("spells", f"[data home]={data_dir}")
     print()
-    usage = """spells [add|refresh|remove|clean] [set_code]
+    usage = """spells [add|refresh|remove|clean] [set_code] [event_type]
             spells clean all
             spells info
 
@@ -57,6 +57,13 @@ def cli() -> int:
         [set code] should be the capitalized official set code for the draft release.
 
         e.g. $ spells add OTJ
+
+        [event_type] is optional and defaults to PremierDraft. Pass a 17Lands event type
+        (e.g. PickTwoDraft) to download an alternate draft format. The draft, game, and
+        card downloads are format-agnostic; only the set context (and summon) are not
+        supported for multi-pick formats yet.
+
+        e.g. $ spells add OM1 PickTwoDraft
 
     refresh: Force download and overwrite of existing files (for new data drops, use sparingly!). Clear
         local
@@ -78,34 +85,71 @@ def cli() -> int:
     if mode == "info":
         return _info()
 
-    if len(sys.argv) != 3:
+    if len(sys.argv) not in (3, 4):
         print_usage()
         return 1
 
+    set_code = sys.argv[2]
+
+    if len(sys.argv) == 4:
+        try:
+            event_type = cache.EventType(sys.argv[3])
+        except ValueError:
+            cache.spells_print(
+                "usage",
+                f"Unknown event type '{sys.argv[3]}'; expected one of "
+                f"{[e.value for e in cache.EventType]}",
+            )
+            return 1
+    else:
+        event_type = cache.EventType.PREMIER
+
     match mode:
         case "add":
-            return _add(sys.argv[2])
+            return _add(set_code, event_type=event_type)
         case "refresh":
-            return _refresh(sys.argv[2])
+            return _refresh(set_code, event_type=event_type)
         case "remove":
-            return _remove(sys.argv[2])
+            return _remove(set_code)
         case "clean":
-            return cache.clean(sys.argv[2])
+            return cache.clean(set_code)
         case _:
             print_usage()
             return 1
 
 
-def _add(set_code: str, force_download: bool = False) -> int:
-    download_data_set(set_code, View.DRAFT, force_download=force_download)
-    cards.write_card_file(set_code, force_download=force_download)
-    get_set_context(set_code, force_download=force_download)
-    download_data_set(set_code, View.GAME, force_download=force_download)
+def _add(
+    set_code: str,
+    event_type: cache.EventType = cache.EventType.PREMIER,
+    force_download: bool = False,
+) -> int:
+    mode = "refresh" if force_download else "add"
+    cache.spells_print(mode, f"Adding {set_code} {event_type} to {cache.external_set_path(set_code)}")
+
+    download_data_set(
+        set_code, View.DRAFT, event_type=event_type, force_download=force_download
+    )
+    cards.write_card_file(set_code, event_type=event_type, force_download=force_download)
+    download_data_set(
+        set_code, View.GAME, event_type=event_type, force_download=force_download
+    )
+
+    if event_type == cache.EventType.PREMIER:
+        get_set_context(set_code, force_download=force_download)
+    else:
+        # get_set_context is the only step driven by summon(), which still bakes
+        # in the one-pick-per-row assumption and can't aggregate multi-pick
+        # formats yet. The raw draft/game/card downloads are format-agnostic.
+        cache.spells_print(
+            "add",
+            f"Skipping set context for {event_type} "
+            "(summon does not support multi-pick formats yet)",
+        )
     return 0
 
 
-def _refresh(set_code: str):
-    return _add(set_code, force_download=True)
+def _refresh(set_code: str, event_type: cache.EventType = cache.EventType.PREMIER):
+    return _add(set_code, event_type=event_type, force_download=True)
 
 
 def _remove(set_code: str):
@@ -236,12 +280,15 @@ def download_data_set(
     clear_set_cache=True,
 ):
     mode = "refresh" if force_download else "add"
-    cache.spells_print(mode, f"Downloading {dataset_type} dataset from 17Lands.com")
+    cache.spells_print(
+        mode,
+        f"Downloading {set_code} {event_type} {dataset_type} dataset from 17Lands.com",
+    )
 
     if not os.path.isdir(set_dir := cache.external_set_path(set_code)):
         os.makedirs(set_dir)
 
-    target_path = cache.data_file_path(set_code, dataset_type)
+    target_path = cache.data_file_path(set_code, dataset_type, event_type)
 
     if os.path.isfile(target_path) and not force_download:
         cache.spells_print(
@@ -253,11 +300,10 @@ def download_data_set(
     dataset_file = DATASET_TEMPLATE.format(
         set_code=set_code, dataset_type=dataset_type, event_type=event_type
     )
+    source_url = RESOURCE_TEMPLATE.format(dataset_type=dataset_type) + dataset_file
     dataset_path = os.path.join(cache.external_set_path(set_code), dataset_file)
-    wget.download(
-        RESOURCE_TEMPLATE.format(dataset_type=dataset_type) + dataset_file,
-        out=dataset_path,
-    )
+    cache.spells_print(mode, f"Fetching {source_url}")
+    wget.download(source_url, out=dataset_path)
     print()
 
     cache.spells_print(

--- a/spells/external.py
+++ b/spells/external.py
@@ -98,7 +98,7 @@ def cli() -> int:
 
 def _add(set_code: str, force_download: bool = False) -> int:
     download_data_set(set_code, View.DRAFT, force_download=force_download)
-    write_card_file(set_code, force_download=force_download)
+    cards.write_card_file(set_code, force_download=force_download)
     get_set_context(set_code, force_download=force_download)
     download_data_set(set_code, View.GAME, force_download=force_download)
     return 0
@@ -268,47 +268,6 @@ def download_data_set(
     if clear_set_cache:
         cache.clean(set_code)
 
-    return 0
-
-
-def write_card_file(draft_set_code: str, force_download=False) -> int:
-    """
-    Write a csv containing basic information about draftable cards, such as rarity,
-    set symbol, color, mana cost, and type.
-    """
-    mode = "refresh" if force_download else "add"
-
-    cache.spells_print(
-        mode, "Fetching card data from mtgjson.com and writing card file"
-    )
-    card_filepath = cache.data_file_path(draft_set_code, View.CARD)
-    if os.path.isfile(card_filepath) and not force_download:
-        cache.spells_print(
-            mode,
-            f"File {card_filepath} already exists, use `spells refresh {draft_set_code}` to overwrite",
-        )
-        return 1
-
-    draft_filepath = cache.data_file_path(draft_set_code, View.DRAFT)
-
-    if not os.path.isfile(draft_filepath):
-        cache.spells_print(mode, f"Error: No draft file for set {draft_set_code}")
-        return 1
-
-    columns = pl.scan_parquet(draft_filepath).collect_schema().names()
-
-    pattern = "^pack_card_"
-    names = [
-        re.split(pattern, name)[1]
-        for name in columns
-        if re.search(pattern, name) is not None
-    ]
-
-    card_df = cards.card_df(draft_set_code, names)
-
-    card_df.write_parquet(card_filepath)
-
-    cache.spells_print(mode, f"Wrote file {card_filepath}")
     return 0
 
 

--- a/spells/schema.py
+++ b/spells/schema.py
@@ -27,6 +27,7 @@ COLUMN_TYPES = (
     (re.compile(r"^pack_number$"), pl.Int8),
     (re.compile(r"^pick_number$"), pl.Int8),
     (re.compile(r"^pick$"), pl.String),
+    (re.compile(r"^pick_2$"), pl.String),
     (re.compile(r"^pick_maindeck_rate$"), pl.Float64),
     (re.compile(r"^pick_sideboard_in_rate$"), pl.Float64),
     (re.compile(r"^pool_.*"), pl.Int8),

--- a/tests/draft_model_test.py
+++ b/tests/draft_model_test.py
@@ -5,10 +5,21 @@ Test the Draft object model built from 17lands draft data responses.
 import json
 import os
 
+import polars as pl
 import pytest
+from polars.testing import assert_frame_equal
 
 import spells.draft_model as draft_model
-from spells.draft_model import Draft, DraftCard, _draft_from_data, fetch_draft
+from spells import cache
+from spells.draft_model import (
+    Draft,
+    DraftCard,
+    _draft_from_data,
+    draft_view_df,
+    fetch_draft,
+    view_draft,
+)
+from spells.enums import View
 
 
 def card(name: str) -> dict:
@@ -226,3 +237,126 @@ def test_fetch_draft_without_card_data(tmp_path, monkeypatch: pytest.MonkeyPatch
     draft = fetch_draft("abc123", card_data=False)
 
     assert draft.picks[0].pack_cards[0].rarity is None
+
+
+VIEW_NAMES = ["Aether Sprite", "Blazing Howl", "Crystal Idol"]
+
+VIEW_SCHEMA = {
+    "expansion": pl.String,
+    "event_type": pl.String,
+    "draft_id": pl.String,
+    "draft_time": pl.String,
+    "rank": pl.String,
+    "event_match_wins": pl.Int8,
+    "event_match_losses": pl.Int8,
+    "pack_number": pl.Int8,
+    "pick_number": pl.Int8,
+    "pick": pl.String,
+    "pick_maindeck_rate": pl.Float64,
+    "pick_sideboard_in_rate": pl.Float64,
+    "user_n_games_bucket": pl.Int16,
+    "user_game_win_rate_bucket": pl.Float64,
+    **{f"pool_{n}": pl.Int8 for n in VIEW_NAMES},
+    **{f"pack_card_{n}": pl.Int8 for n in VIEW_NAMES},
+}
+
+
+def view_row(draft_id, pack_number, pick_number, pack, pool, pick, rank="gold"):
+    row = {
+        "expansion": "TST",
+        "event_type": "PremierDraft",
+        "draft_id": draft_id,
+        "draft_time": "2026-01-01 10:00:00",
+        "rank": rank,
+        "event_match_wins": 3,
+        "event_match_losses": 1,
+        "pack_number": pack_number,
+        "pick_number": pick_number,
+        "pick": pick,
+        "pick_maindeck_rate": 1.0,
+        "pick_sideboard_in_rate": 0.0,
+        "user_n_games_bucket": 100,
+        "user_game_win_rate_bucket": 0.55,
+    }
+    for n in VIEW_NAMES:
+        row[f"pool_{n}"] = pool.get(n, 0)
+        row[f"pack_card_{n}"] = pack.get(n, 0)
+    return row
+
+
+@pytest.fixture()
+def fake_view(tmp_path, monkeypatch: pytest.MonkeyPatch) -> pl.DataFrame:
+    monkeypatch.setenv("SPELLS_DATA_HOME", str(tmp_path))
+    rows = [
+        view_row("d1", 0, 0, {"Crystal Idol": 2, "Aether Sprite": 1}, {}, "Crystal Idol"),
+        view_row("d1", 0, 1, {"Blazing Howl": 1}, {"Crystal Idol": 1}, "Blazing Howl"),
+        view_row("d2", 0, 0, {"Aether Sprite": 1}, {}, "Aether Sprite", rank="bronze"),
+    ]
+    df = pl.DataFrame(rows, schema=VIEW_SCHEMA)
+    fp = cache.data_file_path("TST", View.DRAFT)
+    os.makedirs(os.path.dirname(fp), exist_ok=True)
+    df.write_parquet(fp)
+    return df
+
+
+def test_view_draft_by_id(fake_view):
+    draft = view_draft("TST", "d1", card_data=False)
+
+    assert draft.expansion == "TST"
+    assert draft.draft_id == "d1"
+    assert draft.rank == "gold"
+    assert draft.event_match_wins == 3
+    assert draft.user_n_games_bucket == 100
+
+    first = draft.picks[0]
+    assert (first.pack_num, first.pick_num) == (1, 1)
+    # pack expands count columns with multiplicity, in column (name) order
+    assert [c.name for c in first.pack_cards] == [
+        "Aether Sprite", "Crystal Idol", "Crystal Idol",
+    ]
+    assert first.pick_ind == 1
+    assert first.picks_ind == [1]
+    assert first.pick_maindeck_rate == 1.0
+
+    second = draft.picks[1]
+    assert [c.name for c in second.pool] == ["Crystal Idol"]
+
+
+def test_view_draft_sampling(fake_view):
+    draft = view_draft(
+        "TST", filter_expr=pl.col("rank") == "bronze", seed=1, card_data=False
+    )
+    assert draft.draft_id == "d2"
+
+    # seeded sampling is deterministic
+    a = view_draft("TST", seed=7, card_data=False)
+    b = view_draft("TST", seed=7, card_data=False)
+    assert a.draft_id == b.draft_id
+
+
+def test_view_draft_no_match_raises(fake_view):
+    with pytest.raises(ValueError):
+        view_draft("TST", filter_expr=pl.col("rank") == "mythic", card_data=False)
+
+
+def test_view_round_trip(fake_view):
+    draft = view_draft("TST", "d1", card_data=False)
+    df = draft_view_df(draft)
+
+    expected = fake_view.filter(pl.col("draft_id") == "d1")
+    assert_frame_equal(df, expected)
+
+
+def test_draft_view_df_constructed_schema(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    # no local view file: schema is constructed from the draft's own cards
+    monkeypatch.setenv("SPELLS_DATA_HOME", str(tmp_path))
+    draft = _draft_from_data("abc123", FAKE_DATA)
+
+    df = draft_view_df(draft)
+
+    assert df.height == 3
+    assert df["pack_number"].to_list() == [0, 0, 1]
+    assert df["pick"].to_list() == ["Aether Sprite", "Tidal Reckoning", "Crystal Idol"]
+    assert df["pool_Aether Sprite"].to_list() == [0, 1, 1]
+    assert df["rank"][0] is None
+    assert df.schema["pack_card_Crystal Idol"] == pl.Int8

--- a/tests/draft_model_test.py
+++ b/tests/draft_model_test.py
@@ -3,6 +3,7 @@ Test the Draft object model built from 17lands draft data responses.
 """
 
 import json
+import os
 
 import pytest
 
@@ -108,12 +109,95 @@ def test_missing_pick_gives_none_ind():
     assert state.pool == []
 
 
+FAKE_ATTR_MAP = {
+    "Aether Sprite": {
+        "set_code": "TST",
+        "color": "U",
+        "rarity": "common",
+        "card_type": "Creature",
+        "mana_value": 2.0,
+        "mana_cost": "{1}{U}",
+        "oracle_text": "Flying",
+        "image_url": "https://attr-img/Aether Sprite.jpg",
+    },
+}
+
+
+def test_attr_map_populates_card_fields():
+    draft = _draft_from_data("abc123", FAKE_DATA, FAKE_ATTR_MAP)
+    sprite = draft.picks[0].pack_cards[0]
+
+    assert sprite.set_code == "TST"
+    assert sprite.color == "U"
+    assert sprite.rarity == "common"
+    assert sprite.card_type == "Creature"
+    assert sprite.mana_value == 2.0
+    assert sprite.oracle_text == "Flying"
+    # the feed image_url wins over the card-file one
+    assert sprite.image_url == "https://img/Aether Sprite.jpg"
+
+    # cards missing from the attr map parse bare
+    howl = draft.picks[0].pack_cards[1]
+    assert howl.name == "Blazing Howl"
+    assert howl.set_code is None
+    assert howl.rarity is None
+
+
+def test_card_attr_map_reads_card_file(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    import polars as pl
+
+    from spells import cache
+    from spells.enums import View
+
+    monkeypatch.setenv("SPELLS_DATA_HOME", str(tmp_path))
+
+    file_path = cache.data_file_path("TST", View.CARD)
+    os.makedirs(os.path.dirname(file_path))
+    pl.DataFrame(
+        [{"name": "Aether Sprite", "set_code": "TST", "rarity": "common"}]
+    ).write_parquet(file_path)
+
+    attr_map = draft_model._card_attr_map("TST", ["Aether Sprite"])
+
+    assert attr_map["Aether Sprite"]["rarity"] == "common"
+
+
+def test_card_attr_map_falls_back_to_mtgjson(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    import polars as pl
+
+    monkeypatch.setenv("SPELLS_DATA_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        draft_model,
+        "card_df",
+        lambda expansion, names: pl.DataFrame(
+            [{"name": n, "set_code": expansion, "rarity": "rare"} for n in names]
+        ),
+    )
+
+    attr_map = draft_model._card_attr_map("TST", ["Aether Sprite"])
+
+    assert attr_map["Aether Sprite"]["set_code"] == "TST"
+
+
+def test_card_attr_map_empty_when_unavailable(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    def boom(expansion, names):
+        raise ValueError("no such set")
+
+    monkeypatch.setenv("SPELLS_DATA_HOME", str(tmp_path))
+    monkeypatch.setattr(draft_model, "card_df", boom)
+
+    assert draft_model._card_attr_map("Cube+-+Powered", ["Aether Sprite"]) == {}
+
+
 def test_fetch_draft_reads_cached_file(tmp_path, monkeypatch: pytest.MonkeyPatch):
     file_path = tmp_path / "abc123.json"
     file_path.write_text(json.dumps(FAKE_DATA))
 
     monkeypatch.setattr(
         draft_model, "download_data_file", lambda url, target_dir, filename: str(file_path)
+    )
+    monkeypatch.setattr(
+        draft_model, "_card_attr_map", lambda expansion, names: FAKE_ATTR_MAP
     )
 
     draft = fetch_draft("abc123")
@@ -122,3 +206,23 @@ def test_fetch_draft_reads_cached_file(tmp_path, monkeypatch: pytest.MonkeyPatch
     assert draft.draft_id == "abc123"
     assert len(draft.picks) == 3
     assert isinstance(draft.picks[0].pack_cards[0], DraftCard)
+    # card attrs joined through the fetch path
+    assert draft.picks[0].pack_cards[0].rarity == "common"
+
+
+def test_fetch_draft_without_card_data(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    file_path = tmp_path / "abc123.json"
+    file_path.write_text(json.dumps(FAKE_DATA))
+
+    monkeypatch.setattr(
+        draft_model, "download_data_file", lambda url, target_dir, filename: str(file_path)
+    )
+
+    def no_call(expansion, names):
+        raise AssertionError("_card_attr_map should not be called")
+
+    monkeypatch.setattr(draft_model, "_card_attr_map", no_call)
+
+    draft = fetch_draft("abc123", card_data=False)
+
+    assert draft.picks[0].pack_cards[0].rarity is None

--- a/tests/draft_model_test.py
+++ b/tests/draft_model_test.py
@@ -1,0 +1,124 @@
+"""
+Test the Draft object model built from 17lands draft data responses.
+"""
+
+import json
+
+import pytest
+
+import spells.draft_model as draft_model
+from spells.draft_model import Draft, DraftCard, _draft_from_data, fetch_draft
+
+
+def card(name: str) -> dict:
+    return {"name": name, "image_url": f"https://img/{name}.jpg"}
+
+
+def pick_obj(
+    pack_number: int,
+    pick_number: int,
+    available: list[str],
+    pick: str | None,
+    picks: list[str] | None = None,
+) -> dict:
+    return {
+        "pack_number": pack_number,
+        "pick_number": pick_number,
+        "available": [card(n) for n in available],
+        "pick": card(pick) if pick is not None else None,
+        "picks": [card(n) for n in (picks if picks is not None else ([pick] if pick else []))],
+    }
+
+
+FAKE_DATA = {
+    "expansion": "TST",
+    "num_seats": 8,
+    "picks": [
+        pick_obj(0, 0, ["Aether Sprite", "Blazing Howl", "Crystal Idol"], "Aether Sprite"),
+        pick_obj(0, 1, ["Ember Brute", "Tidal Reckoning"], "Tidal Reckoning"),
+        pick_obj(1, 0, ["Stormcrash Wyvern", "Crystal Idol"], "Crystal Idol"),
+    ],
+}
+
+
+def test_draft_from_data_structure():
+    draft = _draft_from_data("abc123", FAKE_DATA)
+
+    assert draft.expansion == "TST"
+    assert draft.draft_id == "abc123"
+    assert len(draft.picks) == 3
+
+    first = draft.picks[0]
+    assert (first.pack_num, first.pick_num) == (1, 1)  # 0-indexed feed -> 1-indexed model
+    assert [c.name for c in first.pack_cards] == ["Aether Sprite", "Blazing Howl", "Crystal Idol"]
+    assert first.pick_ind == 0
+    assert first.picks_ind == [0]
+    assert first.pool == []
+
+    # cards carry identity only; no environment or metrics attached
+    assert first.pack_cards[0].set_code is None
+    assert first.pack_cards[0].image_url == "https://img/Aether Sprite.jpg"
+
+
+def test_pool_accumulates_prior_picks():
+    draft = _draft_from_data("abc123", FAKE_DATA)
+
+    assert [c.name for c in draft.picks[1].pool] == ["Aether Sprite"]
+    assert [c.name for c in draft.picks[2].pool] == ["Aether Sprite", "Tidal Reckoning"]
+
+
+def test_picks_sorted_by_pack_then_pick():
+    shuffled = {**FAKE_DATA, "picks": list(reversed(FAKE_DATA["picks"]))}
+    draft = _draft_from_data("abc123", shuffled)
+
+    assert [(s.pack_num, s.pick_num) for s in draft.picks] == [(1, 1), (1, 2), (2, 1)]
+    assert [c.name for c in draft.picks[2].pool] == ["Aether Sprite", "Tidal Reckoning"]
+
+
+def test_duplicate_names_consume_distinct_indices():
+    data = {
+        "expansion": "TST",
+        "picks": [
+            pick_obj(
+                0, 0,
+                ["Crystal Idol", "Crystal Idol", "Aether Sprite"],
+                "Crystal Idol",
+                picks=["Crystal Idol", "Crystal Idol"],
+            ),
+        ],
+    }
+    state = _draft_from_data("abc123", data).picks[0]
+
+    assert state.pick_ind == 0
+    assert state.picks_ind == [0, 1]
+    assert [c.name for c in _draft_from_data("abc123", data).picks[0].pack_cards] == [
+        "Crystal Idol", "Crystal Idol", "Aether Sprite",
+    ]
+
+
+def test_missing_pick_gives_none_ind():
+    data = {
+        "expansion": "TST",
+        "picks": [pick_obj(0, 0, ["Aether Sprite"], None)],
+    }
+    state = _draft_from_data("abc123", data).picks[0]
+
+    assert state.pick_ind is None
+    assert state.picks_ind == []
+    assert state.pool == []
+
+
+def test_fetch_draft_reads_cached_file(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    file_path = tmp_path / "abc123.json"
+    file_path.write_text(json.dumps(FAKE_DATA))
+
+    monkeypatch.setattr(
+        draft_model, "download_data_file", lambda url, target_dir, filename: str(file_path)
+    )
+
+    draft = fetch_draft("abc123")
+
+    assert isinstance(draft, Draft)
+    assert draft.draft_id == "abc123"
+    assert len(draft.picks) == 3
+    assert isinstance(draft.picks[0].pack_cards[0], DraftCard)

--- a/tests/draft_model_test.py
+++ b/tests/draft_model_test.py
@@ -17,7 +17,7 @@ from spells.draft_model import (
     _draft_from_data,
     draft_view_df,
     fetch_draft,
-    view_draft,
+    draft_from_public_data,
 )
 from spells.enums import View
 
@@ -285,9 +285,46 @@ def view_row(draft_id, pack_number, pick_number, pack, pool, pick, rank="gold"):
     return row
 
 
+# A minimal card file for the VIEW_NAMES cards. view_select hydrates column
+# defs, which requires a card parquet alongside the draft view (get_names
+# cross-checks the two, and CARD_ATTR columns read from here). One row per
+# VIEW_NAMES card, carrying every CARD_ATTR column.
+CARD_ATTR_ROWS = [
+    {
+        "name": "Aether Sprite", "set_code": "TST", "color": "U", "rarity": "common",
+        "color_identity": "U", "card_type": "Creature", "subtype": "Faerie",
+        "mana_value": 2.0, "mana_cost": "{1}{U}", "power": "1", "toughness": "1",
+        "is_bonus_sheet": False, "is_dfc": False, "oracle_text": "Flying",
+        "card_json": "{}", "scryfall_id": "", "image_url": "",
+    },
+    {
+        "name": "Blazing Howl", "set_code": "TST", "color": "R", "rarity": "uncommon",
+        "color_identity": "R", "card_type": "Instant", "subtype": "",
+        "mana_value": 1.0, "mana_cost": "{R}", "power": None, "toughness": None,
+        "is_bonus_sheet": False, "is_dfc": False,
+        "oracle_text": "Target creature gets +2/+0 until end of turn.",
+        "card_json": "{}", "scryfall_id": "", "image_url": "",
+    },
+    {
+        "name": "Crystal Idol", "set_code": "TST", "color": "", "rarity": "common",
+        "color_identity": "", "card_type": "Artifact", "subtype": "",
+        "mana_value": 2.0, "mana_cost": "{2}", "power": None, "toughness": None,
+        "is_bonus_sheet": False, "is_dfc": False, "oracle_text": "{T}: Add {C}.",
+        "card_json": "{}", "scryfall_id": "", "image_url": "",
+    },
+]
+
+
+def write_card_view(set_code: str = "TST") -> None:
+    fp = cache.data_file_path(set_code, View.CARD)
+    os.makedirs(os.path.dirname(fp), exist_ok=True)
+    pl.DataFrame(CARD_ATTR_ROWS).write_parquet(fp)
+
+
 @pytest.fixture()
 def fake_view(tmp_path, monkeypatch: pytest.MonkeyPatch) -> pl.DataFrame:
     monkeypatch.setenv("SPELLS_DATA_HOME", str(tmp_path))
+    write_card_view()
     rows = [
         view_row("d1", 0, 0, {"Crystal Idol": 2, "Aether Sprite": 1}, {}, "Crystal Idol"),
         view_row("d1", 0, 1, {"Blazing Howl": 1}, {"Crystal Idol": 1}, "Blazing Howl"),
@@ -305,8 +342,8 @@ def fake_view(tmp_path, monkeypatch: pytest.MonkeyPatch) -> pl.DataFrame:
     return df
 
 
-def test_view_draft_by_id(fake_view):
-    draft = view_draft("TST", "d1", card_data=False)
+def test_draft_from_public_data_by_id(fake_view):
+    draft = draft_from_public_data("TST", "d1", card_data=False)
 
     assert draft.expansion == "TST"
     assert draft.draft_id == "d1"
@@ -328,25 +365,25 @@ def test_view_draft_by_id(fake_view):
     assert [c.name for c in second.pool] == ["Crystal Idol"]
 
 
-def test_view_draft_sampling(fake_view):
-    draft = view_draft(
-        "TST", filter_expr=pl.col("rank") == "bronze", seed=1, card_data=False
+def test_draft_from_public_data_sampling(fake_view):
+    draft = draft_from_public_data(
+        "TST", filter_spec={'rank': 'bronze'}, seed=1, card_data=False
     )
     assert draft.draft_id == "d2"
 
     # seeded sampling is deterministic
-    a = view_draft("TST", seed=7, card_data=False)
-    b = view_draft("TST", seed=7, card_data=False)
+    a = draft_from_public_data("TST", seed=7, card_data=False)
+    b = draft_from_public_data("TST", seed=7, card_data=False)
     assert a.draft_id == b.draft_id
 
 
-def test_view_draft_no_match_raises(fake_view):
+def test_draft_from_public_data_no_match_raises(fake_view):
     with pytest.raises(ValueError):
-        view_draft("TST", filter_expr=pl.col("rank") == "mythic", card_data=False)
+        draft_from_public_data("TST", filter_spec={'rank': 'mythic'}, card_data=False)
 
 
 def test_view_round_trip(fake_view):
-    draft = view_draft("TST", "d1", card_data=False)
+    draft = draft_from_public_data("TST", "d1", card_data=False)
     df = draft_view_df(draft)
 
     expected = fake_view.filter(pl.col("draft_id") == "d1")
@@ -355,7 +392,7 @@ def test_view_round_trip(fake_view):
 
 def test_view_pool_promo_cards(fake_view):
     """Cards seeded into the pool outside of picks are recovered from pool_."""
-    draft = view_draft("TST", "d2", card_data=False)
+    draft = draft_from_public_data("TST", "d2", card_data=False)
 
     assert [c.name for c in draft.picks[0].pool] == ["Blazing Howl"]
 
@@ -385,6 +422,7 @@ def fake_view_missing_p1p1(tmp_path, monkeypatch: pytest.MonkeyPatch) -> pl.Data
     is absent from the parquet. The first recorded row is pick_number=1, and
     pool_ at that row reveals the card picked at the missing p1p1."""
     monkeypatch.setenv("SPELLS_DATA_HOME", str(tmp_path))
+    write_card_view()
     rows = [
         # pick_number=0 row is missing; pool at pick_number=1 shows Aether Sprite
         # was already picked (at the unrecorded p1p1)
@@ -398,9 +436,9 @@ def fake_view_missing_p1p1(tmp_path, monkeypatch: pytest.MonkeyPatch) -> pl.Data
     return df
 
 
-def test_view_draft_missing_p1p1_synthesized(fake_view_missing_p1p1):
+def test_draft_from_public_data_missing_p1p1_synthesized(fake_view_missing_p1p1):
     """A missing p1p1 row produces a synthetic DraftState with the inferred pick."""
-    draft = view_draft("TST", "d1", card_data=False)
+    draft = draft_from_public_data("TST", "d1", card_data=False)
 
     # synthetic p1p1 prepended; total states = 1 synthetic + 2 recorded
     assert len(draft.picks) == 3
@@ -417,9 +455,9 @@ def test_view_draft_missing_p1p1_synthesized(fake_view_missing_p1p1):
     assert [c.name for c in p1p2.pool] == ["Aether Sprite"]  # synthetic pick accumulated
 
 
-def test_view_draft_missing_p1p1_round_trip(fake_view_missing_p1p1):
+def test_draft_from_public_data_missing_p1p1_round_trip(fake_view_missing_p1p1):
     """draft_view_df includes the synthetic row — a superset of the parquet source."""
-    draft = view_draft("TST", "d1", card_data=False)
+    draft = draft_from_public_data("TST", "d1", card_data=False)
     df = draft_view_df(draft)
 
     # three rows rendered (synthetic p1p1 + two recorded)
@@ -465,42 +503,42 @@ def fake_pick_two_view(tmp_path, monkeypatch: pytest.MonkeyPatch) -> pl.DataFram
     return df
 
 
-def test_view_draft_pick_two(fake_pick_two_view):
-    draft = view_draft(
-        "TS2", "d1", event_type=cache.EventType.PICK_TWO, card_data=False
-    )
+# def test_draft_from_public_data_pick_two(fake_pick_two_view):
+#     draft = draft_from_public_data(
+#         "TS2", "d1", event_type=cache.EventType.PICK_TWO, card_data=False
+#     )
+# 
+#     first = draft.picks[0]
+#     # pack in column order: Aether Sprite, Blazing Howl, Crystal Idol x2
+#     assert [c.name for c in first.pack_cards] == [
+#         "Aether Sprite", "Blazing Howl", "Crystal Idol", "Crystal Idol",
+#     ]
+#     # pick-two: pick_ind None, both copies consume distinct indices
+#     assert first.pick_ind is None
+#     assert first.picks_ind == [2, 3]
+# 
+#     second = draft.picks[1]
+#     assert second.pick_ind is None
+#     assert second.picks_ind == [0, 1]
+#     # pool corrected by accumulation: both Crystal Idol copies, not the
+#     # file's undercounted single copy
+#     assert [c.name for c in second.pool] == ["Crystal Idol", "Crystal Idol"]
 
-    first = draft.picks[0]
-    # pack in column order: Aether Sprite, Blazing Howl, Crystal Idol x2
-    assert [c.name for c in first.pack_cards] == [
-        "Aether Sprite", "Blazing Howl", "Crystal Idol", "Crystal Idol",
-    ]
-    # pick-two: pick_ind None, both copies consume distinct indices
-    assert first.pick_ind is None
-    assert first.picks_ind == [2, 3]
 
-    second = draft.picks[1]
-    assert second.pick_ind is None
-    assert second.picks_ind == [0, 1]
-    # pool corrected by accumulation: both Crystal Idol copies, not the
-    # file's undercounted single copy
-    assert [c.name for c in second.pool] == ["Crystal Idol", "Crystal Idol"]
-
-
-def test_pick_two_round_trip(fake_pick_two_view):
-    draft = view_draft(
-        "TS2", "d1", event_type=cache.EventType.PICK_TWO, card_data=False
-    )
-    df = draft_view_df(draft)
-
-    # non-pool columns round-trip exactly, including pick_2
-    non_pool = [c for c in fake_pick_two_view.columns if not c.startswith("pool_")]
-    assert_frame_equal(df.select(non_pool), fake_pick_two_view.select(non_pool))
-    assert df["pick_2"].to_list() == ["Crystal Idol", "Blazing Howl"]
-
-    # pool columns come out corrected relative to the source file
-    assert df["pool_Crystal Idol"].to_list() == [0, 2]
-    assert df["pool_Blazing Howl"].to_list() == [0, 0]
+# def test_pick_two_round_trip(fake_pick_two_view):
+#     draft = draft_from_public_data(
+#         "TS2", "d1", event_type=cache.EventType.PICK_TWO, card_data=False
+#     )
+#     df = draft_view_df(draft)
+# 
+#     # non-pool columns round-trip exactly, including pick_2
+#     non_pool = [c for c in fake_pick_two_view.columns if not c.startswith("pool_")]
+#     assert_frame_equal(df.select(non_pool), fake_pick_two_view.select(non_pool))
+#     assert df["pick_2"].to_list() == ["Crystal Idol", "Blazing Howl"]
+# 
+#     # pool columns come out corrected relative to the source file
+#     assert df["pool_Crystal Idol"].to_list() == [0, 2]
+#     assert df["pool_Blazing Howl"].to_list() == [0, 0]
 
 
 def test_live_pick_two_feed():

--- a/tests/draft_model_test.py
+++ b/tests/draft_model_test.py
@@ -101,7 +101,8 @@ def test_duplicate_names_consume_distinct_indices():
     }
     state = _draft_from_data("abc123", data).picks[0]
 
-    assert state.pick_ind == 0
+    # two picks -> pick-two semantics: pick_ind is None, picks_ind holds both
+    assert state.pick_ind is None
     assert state.picks_ind == [0, 1]
     assert [c.name for c in _draft_from_data("abc123", data).picks[0].pack_cards] == [
         "Crystal Idol", "Crystal Idol", "Aether Sprite",
@@ -290,7 +291,11 @@ def fake_view(tmp_path, monkeypatch: pytest.MonkeyPatch) -> pl.DataFrame:
     rows = [
         view_row("d1", 0, 0, {"Crystal Idol": 2, "Aether Sprite": 1}, {}, "Crystal Idol"),
         view_row("d1", 0, 1, {"Blazing Howl": 1}, {"Crystal Idol": 1}, "Blazing Howl"),
-        view_row("d2", 0, 0, {"Aether Sprite": 1}, {}, "Aether Sprite", rank="bronze"),
+        # d2's pool is seeded with a promo card never picked (TLA-style)
+        view_row(
+            "d2", 0, 0, {"Aether Sprite": 1}, {"Blazing Howl": 1},
+            "Aether Sprite", rank="bronze",
+        ),
     ]
     df = pl.DataFrame(rows, schema=VIEW_SCHEMA)
     fp = cache.data_file_path("TST", View.DRAFT)
@@ -347,6 +352,17 @@ def test_view_round_trip(fake_view):
     assert_frame_equal(df, expected)
 
 
+def test_view_pool_promo_cards(fake_view):
+    """Cards seeded into the pool outside of picks are recovered from pool_."""
+    draft = view_draft("TST", "d2", card_data=False)
+
+    assert [c.name for c in draft.picks[0].pool] == ["Blazing Howl"]
+
+    # and they round-trip exactly
+    df = draft_view_df(draft)
+    assert_frame_equal(df, fake_view.filter(pl.col("draft_id") == "d2"))
+
+
 def test_draft_view_df_constructed_schema(tmp_path, monkeypatch: pytest.MonkeyPatch):
     # no local view file: schema is constructed from the draft's own cards
     monkeypatch.setenv("SPELLS_DATA_HOME", str(tmp_path))
@@ -360,3 +376,109 @@ def test_draft_view_df_constructed_schema(tmp_path, monkeypatch: pytest.MonkeyPa
     assert df["pool_Aether Sprite"].to_list() == [0, 1, 1]
     assert df["rank"][0] is None
     assert df.schema["pack_card_Crystal Idol"] == pl.Int8
+
+
+PICK_TWO_SCHEMA = {}
+for _k, _v in VIEW_SCHEMA.items():
+    PICK_TWO_SCHEMA[_k] = _v
+    if _k == "pick":
+        PICK_TWO_SCHEMA["pick_2"] = pl.String
+
+
+@pytest.fixture()
+def fake_pick_two_view(tmp_path, monkeypatch: pytest.MonkeyPatch) -> pl.DataFrame:
+    """Mimics the OM1 PickTwoDraft file: pick_2 column present, and the
+    pool_ columns only track `pick` cards (the 17lands undercount)."""
+    monkeypatch.setenv("SPELLS_DATA_HOME", str(tmp_path))
+    rows = [
+        view_row(
+            "d1", 0, 0,
+            {"Crystal Idol": 2, "Aether Sprite": 1, "Blazing Howl": 1},
+            {}, "Crystal Idol",
+        ),
+        view_row(
+            "d1", 0, 1,
+            {"Aether Sprite": 1, "Blazing Howl": 1},
+            {"Crystal Idol": 1},  # undercount: the pick_2 copy is missing
+            "Aether Sprite",
+        ),
+    ]
+    rows[0]["pick_2"] = "Crystal Idol"  # two copies of the same card
+    rows[1]["pick_2"] = "Blazing Howl"
+    df = pl.DataFrame(rows, schema=PICK_TWO_SCHEMA)
+    fp = cache.data_file_path("TS2", View.DRAFT, cache.EventType.PICK_TWO)
+    os.makedirs(os.path.dirname(fp), exist_ok=True)
+    df.write_parquet(fp)
+    return df
+
+
+def test_view_draft_pick_two(fake_pick_two_view):
+    draft = view_draft(
+        "TS2", "d1", event_type=cache.EventType.PICK_TWO, card_data=False
+    )
+
+    first = draft.picks[0]
+    # pack in column order: Aether Sprite, Blazing Howl, Crystal Idol x2
+    assert [c.name for c in first.pack_cards] == [
+        "Aether Sprite", "Blazing Howl", "Crystal Idol", "Crystal Idol",
+    ]
+    # pick-two: pick_ind None, both copies consume distinct indices
+    assert first.pick_ind is None
+    assert first.picks_ind == [2, 3]
+
+    second = draft.picks[1]
+    assert second.pick_ind is None
+    assert second.picks_ind == [0, 1]
+    # pool corrected by accumulation: both Crystal Idol copies, not the
+    # file's undercounted single copy
+    assert [c.name for c in second.pool] == ["Crystal Idol", "Crystal Idol"]
+
+
+def test_pick_two_round_trip(fake_pick_two_view):
+    draft = view_draft(
+        "TS2", "d1", event_type=cache.EventType.PICK_TWO, card_data=False
+    )
+    df = draft_view_df(draft)
+
+    # non-pool columns round-trip exactly, including pick_2
+    non_pool = [c for c in fake_pick_two_view.columns if not c.startswith("pool_")]
+    assert_frame_equal(df.select(non_pool), fake_pick_two_view.select(non_pool))
+    assert df["pick_2"].to_list() == ["Crystal Idol", "Blazing Howl"]
+
+    # pool columns come out corrected relative to the source file
+    assert df["pool_Crystal Idol"].to_list() == [0, 2]
+    assert df["pool_Blazing Howl"].to_list() == [0, 0]
+
+
+def test_live_pick_two_feed():
+    data = {
+        "expansion": "OM1",
+        "picks": [
+            pick_obj(
+                0, 0,
+                ["Aether Sprite", "Blazing Howl", "Crystal Idol", "Ember Brute"],
+                "Aether Sprite",
+                picks=["Aether Sprite", "Crystal Idol"],
+            ),
+        ],
+    }
+    state = _draft_from_data("abc123", data).picks[0]
+
+    assert state.pick_ind is None
+    assert state.picks_ind == [0, 2]
+
+
+def test_live_feed_pool_promo_from_sections():
+    p1 = pick_obj(0, 0, ["Aether Sprite", "Blazing Howl"], "Aether Sprite")
+    p2 = pick_obj(0, 1, ["Crystal Idol"], "Crystal Idol")
+    # the feed's sections show a promo card that never appears in picks
+    p2["sections"] = [
+        {
+            "title": "Possible Maindeck",
+            "cards": [[card("Ember Brute")], [card("Aether Sprite")]],
+        },
+    ]
+    draft = _draft_from_data("abc123", {"expansion": "TST", "picks": [p1, p2]})
+
+    # promo prepended, accumulated picks follow in pick order
+    assert [c.name for c in draft.picks[1].pool] == ["Ember Brute", "Aether Sprite"]

--- a/tests/draft_model_test.py
+++ b/tests/draft_model_test.py
@@ -19,7 +19,8 @@ from spells.draft_model import (
     fetch_draft,
     draft_from_public_data,
 )
-from spells.enums import View
+from spells.draft_data import view_select
+from spells.enums import View, ColName
 
 
 def card(name: str) -> dict:
@@ -400,6 +401,21 @@ def test_view_pool_promo_cards(fake_view):
     # and they round-trip exactly
     df = draft_view_df(draft)
     assert_frame_equal(df, fake_view.filter(pl.col("draft_id") == "d2"))
+
+
+def test_pool_count_builtin(fake_view):
+    """pool_count sums the pool_ columns horizontally for each pick row."""
+    df = (
+        view_select(
+            "TST",
+            View.DRAFT,
+            [ColName.DRAFT_ID, ColName.PICK_NUMBER, ColName.POOL_COUNT],
+        )
+        .sort(ColName.DRAFT_ID, ColName.PICK_NUMBER)
+        .collect()
+    )
+    # d1 p0: empty pool -> 0; d1 p1: one card -> 1; d2 p0: one promo card -> 1
+    assert df[ColName.POOL_COUNT].to_list() == [0, 1, 1]
 
 
 def test_draft_view_df_constructed_schema(tmp_path, monkeypatch: pytest.MonkeyPatch):

--- a/tests/draft_model_test.py
+++ b/tests/draft_model_test.py
@@ -291,7 +291,8 @@ def fake_view(tmp_path, monkeypatch: pytest.MonkeyPatch) -> pl.DataFrame:
     rows = [
         view_row("d1", 0, 0, {"Crystal Idol": 2, "Aether Sprite": 1}, {}, "Crystal Idol"),
         view_row("d1", 0, 1, {"Blazing Howl": 1}, {"Crystal Idol": 1}, "Blazing Howl"),
-        # d2's pool is seeded with a promo card never picked (TLA-style)
+        # d2: pick_number=0 row is present, but pool already has a card before
+        # any pick — models a true game-mechanic promo/seed (row not missing)
         view_row(
             "d2", 0, 0, {"Aether Sprite": 1}, {"Blazing Howl": 1},
             "Aether Sprite", rank="bronze",
@@ -376,6 +377,58 @@ def test_draft_view_df_constructed_schema(tmp_path, monkeypatch: pytest.MonkeyPa
     assert df["pool_Aether Sprite"].to_list() == [0, 1, 1]
     assert df["rank"][0] is None
     assert df.schema["pack_card_Crystal Idol"] == pl.Int8
+
+
+@pytest.fixture()
+def fake_view_missing_p1p1(tmp_path, monkeypatch: pytest.MonkeyPatch) -> pl.DataFrame:
+    """Mimics sets affected by the Arena client bug: pack 0 pick_number=0 row
+    is absent from the parquet. The first recorded row is pick_number=1, and
+    pool_ at that row reveals the card picked at the missing p1p1."""
+    monkeypatch.setenv("SPELLS_DATA_HOME", str(tmp_path))
+    rows = [
+        # pick_number=0 row is missing; pool at pick_number=1 shows Aether Sprite
+        # was already picked (at the unrecorded p1p1)
+        view_row("d1", 0, 1, {"Blazing Howl": 1}, {"Aether Sprite": 1}, "Blazing Howl"),
+        view_row("d1", 0, 2, {}, {"Aether Sprite": 1, "Blazing Howl": 1}, None),
+    ]
+    df = pl.DataFrame(rows, schema=VIEW_SCHEMA)
+    fp = cache.data_file_path("TST", View.DRAFT)
+    os.makedirs(os.path.dirname(fp), exist_ok=True)
+    df.write_parquet(fp)
+    return df
+
+
+def test_view_draft_missing_p1p1_synthesized(fake_view_missing_p1p1):
+    """A missing p1p1 row produces a synthetic DraftState with the inferred pick."""
+    draft = view_draft("TST", "d1", card_data=False)
+
+    # synthetic p1p1 prepended; total states = 1 synthetic + 2 recorded
+    assert len(draft.picks) == 3
+
+    p1p1 = draft.picks[0]
+    assert (p1p1.pack_num, p1p1.pick_num) == (1, 1)
+    assert [c.name for c in p1p1.pack_cards] == ["Aether Sprite"]  # only known card
+    assert p1p1.pick_ind == 0
+    assert p1p1.picks_ind == [0]
+    assert p1p1.pool == []  # nothing before first pick
+
+    p1p2 = draft.picks[1]
+    assert (p1p2.pack_num, p1p2.pick_num) == (1, 2)
+    assert [c.name for c in p1p2.pool] == ["Aether Sprite"]  # synthetic pick accumulated
+
+
+def test_view_draft_missing_p1p1_round_trip(fake_view_missing_p1p1):
+    """draft_view_df includes the synthetic row — a superset of the parquet source."""
+    draft = view_draft("TST", "d1", card_data=False)
+    df = draft_view_df(draft)
+
+    # three rows rendered (synthetic p1p1 + two recorded)
+    assert df.height == 3
+    assert df["pick_number"].to_list() == [0, 1, 2]
+    assert df["pick"][0] == "Aether Sprite"
+    # synthetic row has only the picked card in the pack
+    assert df["pack_card_Aether Sprite"][0] == 1
+    assert df["pack_card_Blazing Howl"][0] == 0
 
 
 PICK_TWO_SCHEMA = {}

--- a/tests/draft_model_test.py
+++ b/tests/draft_model_test.py
@@ -318,7 +318,8 @@ CARD_ATTR_ROWS = [
 def write_card_view(set_code: str = "TST") -> None:
     fp = cache.data_file_path(set_code, View.CARD)
     os.makedirs(os.path.dirname(fp), exist_ok=True)
-    pl.DataFrame(CARD_ATTR_ROWS).write_parquet(fp)
+    rows = [{**r, "set_code": set_code} for r in CARD_ATTR_ROWS]
+    pl.DataFrame(rows).write_parquet(fp)
 
 
 @pytest.fixture()
@@ -481,6 +482,7 @@ def fake_pick_two_view(tmp_path, monkeypatch: pytest.MonkeyPatch) -> pl.DataFram
     """Mimics the OM1 PickTwoDraft file: pick_2 column present, and the
     pool_ columns only track `pick` cards (the 17lands undercount)."""
     monkeypatch.setenv("SPELLS_DATA_HOME", str(tmp_path))
+    write_card_view("TS2")
     rows = [
         view_row(
             "d1", 0, 0,
@@ -503,42 +505,42 @@ def fake_pick_two_view(tmp_path, monkeypatch: pytest.MonkeyPatch) -> pl.DataFram
     return df
 
 
-# def test_draft_from_public_data_pick_two(fake_pick_two_view):
-#     draft = draft_from_public_data(
-#         "TS2", "d1", event_type=cache.EventType.PICK_TWO, card_data=False
-#     )
-# 
-#     first = draft.picks[0]
-#     # pack in column order: Aether Sprite, Blazing Howl, Crystal Idol x2
-#     assert [c.name for c in first.pack_cards] == [
-#         "Aether Sprite", "Blazing Howl", "Crystal Idol", "Crystal Idol",
-#     ]
-#     # pick-two: pick_ind None, both copies consume distinct indices
-#     assert first.pick_ind is None
-#     assert first.picks_ind == [2, 3]
-# 
-#     second = draft.picks[1]
-#     assert second.pick_ind is None
-#     assert second.picks_ind == [0, 1]
-#     # pool corrected by accumulation: both Crystal Idol copies, not the
-#     # file's undercounted single copy
-#     assert [c.name for c in second.pool] == ["Crystal Idol", "Crystal Idol"]
+def test_draft_from_public_data_pick_two(fake_pick_two_view):
+    draft = draft_from_public_data(
+        "TS2", "d1", event_type=cache.EventType.PICK_TWO, card_data=False
+    )
+
+    first = draft.picks[0]
+    # pack in column order: Aether Sprite, Blazing Howl, Crystal Idol x2
+    assert [c.name for c in first.pack_cards] == [
+        "Aether Sprite", "Blazing Howl", "Crystal Idol", "Crystal Idol",
+    ]
+    # pick-two: pick_ind None, both copies consume distinct indices
+    assert first.pick_ind is None
+    assert first.picks_ind == [2, 3]
+
+    second = draft.picks[1]
+    assert second.pick_ind is None
+    assert second.picks_ind == [0, 1]
+    # pool corrected by accumulation: both Crystal Idol copies, not the
+    # file's undercounted single copy
+    assert [c.name for c in second.pool] == ["Crystal Idol", "Crystal Idol"]
 
 
-# def test_pick_two_round_trip(fake_pick_two_view):
-#     draft = draft_from_public_data(
-#         "TS2", "d1", event_type=cache.EventType.PICK_TWO, card_data=False
-#     )
-#     df = draft_view_df(draft)
-# 
-#     # non-pool columns round-trip exactly, including pick_2
-#     non_pool = [c for c in fake_pick_two_view.columns if not c.startswith("pool_")]
-#     assert_frame_equal(df.select(non_pool), fake_pick_two_view.select(non_pool))
-#     assert df["pick_2"].to_list() == ["Crystal Idol", "Blazing Howl"]
-# 
-#     # pool columns come out corrected relative to the source file
-#     assert df["pool_Crystal Idol"].to_list() == [0, 2]
-#     assert df["pool_Blazing Howl"].to_list() == [0, 0]
+def test_pick_two_round_trip(fake_pick_two_view):
+    draft = draft_from_public_data(
+        "TS2", "d1", event_type=cache.EventType.PICK_TWO, card_data=False
+    )
+    df = draft_view_df(draft)
+
+    # non-pool columns round-trip exactly, including pick_2
+    non_pool = [c for c in fake_pick_two_view.columns if not c.startswith("pool_")]
+    assert_frame_equal(df.select(non_pool), fake_pick_two_view.select(non_pool))
+    assert df["pick_2"].to_list() == ["Crystal Idol", "Blazing Howl"]
+
+    # pool columns come out corrected relative to the source file
+    assert df["pool_Crystal Idol"].to_list() == [0, 2]
+    assert df["pool_Blazing Howl"].to_list() == [0, 0]
 
 
 def test_live_pick_two_feed():

--- a/tests/external_test.py
+++ b/tests/external_test.py
@@ -1,0 +1,56 @@
+"""
+Tests for the `spells add` orchestration in external.py. These pin the call
+pattern (which files get downloaded/written) without touching the network.
+"""
+
+import pytest
+
+from spells import cache, external
+from spells.enums import View
+
+
+@pytest.fixture()
+def record_io(monkeypatch: pytest.MonkeyPatch):
+    """Replace the IO steps of `_add` with recorders, returning the call log."""
+    calls: dict[str, list] = {"download": [], "card": [], "context": []}
+
+    def fake_download(set_code, dataset_type, event_type=cache.EventType.PREMIER, **kw):
+        calls["download"].append((set_code, dataset_type, event_type))
+        return 0
+
+    def fake_card(set_code, event_type=cache.EventType.PREMIER, **kw):
+        calls["card"].append((set_code, event_type))
+        return 0
+
+    def fake_context(set_code, **kw):
+        calls["context"].append(set_code)
+        return 0
+
+    monkeypatch.setattr(external, "download_data_set", fake_download)
+    monkeypatch.setattr(external.cards, "write_card_file", fake_card)
+    monkeypatch.setattr(external, "get_set_context", fake_context)
+    return calls
+
+
+def test_add_premier_downloads_full_set(record_io):
+    external._add("TST")
+
+    assert record_io["download"] == [
+        ("TST", View.DRAFT, cache.EventType.PREMIER),
+        ("TST", View.GAME, cache.EventType.PREMIER),
+    ]
+    assert record_io["card"] == [("TST", cache.EventType.PREMIER)]
+    assert record_io["context"] == ["TST"]
+
+
+def test_add_pick_two_skips_only_set_context(record_io):
+    external._add("OM1", event_type=cache.EventType.PICK_TWO)
+
+    # draft + game + card download identically; only the summon-driven set
+    # context is skipped for multi-pick formats
+    assert record_io["download"] == [
+        ("OM1", View.DRAFT, cache.EventType.PICK_TWO),
+        ("OM1", View.GAME, cache.EventType.PICK_TWO),
+    ]
+    assert record_io["card"] == [("OM1", cache.EventType.PICK_TWO)]
+    assert record_io["context"] == []


### PR DESCRIPTION
## Summary

Adds an object model for individual drafts with three interchangeable sources: the live 17lands draft endpoint, the local draft view (public dataset parquet), and back out to a view-schema dataframe.

### Model (`spells/draft_model.py`)
- `Draft` → `DraftState` → `DraftCard` dataclasses. A draft is a succession of states indexed by `pack_num`/`pick_num` (1-indexed, as `ColName.PACK_NUM`); picks are identified by index into `pack_cards` (`pick_ind`, `picks_ind` for pick-two); `pool` accumulates prior picks
- `Draft` carries the view's draft-level metadata (`event_type`, `draft_time`, `rank`, `event_match_wins/losses`, user buckets); `DraftState` carries `pick_maindeck_rate`/`pick_sideboard_in_rate` — all `None` on the live path
- Cards carry identity + static MTGJSON attributes, no metrics; metric annotation joins on name downstream

### Factories / converters
- `fetch_draft(draft_id, card_data=True)` — live 17lands endpoint; draft JSONs are immutable and cached indefinitely under `draft/{id}.json`
- `view_draft(set_code, draft_id=None, *, filter_expr, seed, card_data)` — look up by id or sample a random draft matching a raw polars expression. Two-pass streaming: matching ids first, then one draft's rows; the full view is never materialized
- `draft_view_df(draft)` — one row per state matching the draft view schema exactly (column order + dtypes from the local file when present; constructed otherwise). Round-trip verified `assert_frame_equal`-exact on a live TLA draft (41×708)

### MTGJSON card attributes
- `DraftCard` gains all spells card attrs (rarity, color, mana_value, oracle_text, …); `set_code` is the card's own printing set
- `_card_attr_map` tiers: local card file → auto `write_card_file` when the public draft file exists → live MTGJSON with the draft's own names → bare cards (cubes)
- `write_card_file` moved `external.py` → `cards.py`, fixing the circular import in `draft_data`'s new auto-write of missing card files
- Shared `download_data_file()` extracted in `card_data_files.py`; both ratings fetchers refactored onto it

### Misc
- 17lands feed keys indexed via `ColName` enums (values match 17lands field names by design)
- `CardDataFileSpec.start_date` now required
- `Draft`, `DraftState`, `DraftCard`, `fetch_draft`, `view_draft`, `draft_view_df` exported

## Test plan
- `pdm run pytest` — 47 passing (16 in `draft_model_test.py`: parse, indexing, pool accumulation, duplicates, attr-map tiers, sampling determinism, round-trip)
- `pdm run ruff check .` clean
- Live: `fetch_draft` on a real TLA draft id; `view_draft("TLA", filter_expr=pl.col("rank")=="mythic", seed=42)` → exact round-trip through `draft_view_df`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
