### PR TITLE
Improve publish workflow: tag trigger, test gate, Python 3.13

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,27 +1,51 @@
 name: Publish to PyPI
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
 
 jobs:
-  publish:
+  test:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: '3.13'
 
-      - name: Install pdm
+      - name: Install PDM
+        run: pip install pdm
+
+      - name: Install dependencies
+        run: pdm install
+
+      - name: Run tests
+        run: pdm run pytest
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install PDM
         run: pip install pdm
 
       - name: Build
         run: pdm build
 
-      - name: Publish
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "polars==1.22.0",
     "wget>=3.2",
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.13"
 readme = "README.md"
 license = {text = "MIT"}
 


### PR DESCRIPTION
## Summary

- Switches CI trigger from `release: published` to `push: tags: v*` — fires directly on tag push (which `scripts/release.sh` already does) rather than requiring a separate GitHub Release event
- Adds a `test` job that runs pytest before publish, so a broken release is blocked rather than published
- Pins Python to 3.13 in CI to match actual test environment; bumps `requires-python` to `>=3.13` accordingly
- Adds `environment: pypi` and `fetch-depth: 0` to the publish job

## Test plan

- [ ] Verify next release tag triggers the workflow and both jobs run
- [ ] Confirm publish job is gated on test job passing

🤖 Generated with [Claude Code](https://claude.ai/claude-code)