### PR TITLE
Always include basic lands in the card file

### DIFF
--- a/spells/cards.py
+++ b/spells/cards.py
@@ -165,7 +165,7 @@ def write_card_file(
     `spells refresh {set_code}` to regenerate. With force_download=True:
     always overwrites.
     """
-    names = list(set(names) | BASIC_LANDS)
+    names = sorted(set(names) | BASIC_LANDS)
     mode = "refresh" if force_download else "add"
     card_filepath = cache.data_file_path(draft_set_code, View.CARD)
 

--- a/spells/cards.py
+++ b/spells/cards.py
@@ -146,6 +146,14 @@ def names_from_parquet(draft_set_code: str, event_type: EventType) -> list[str]:
     return [col[len(prefix):] for col in columns if col.startswith(prefix)]
 
 
+BASIC_LANDS = ("Plains", "Island", "Swamp", "Mountain", "Forest")
+
+
+def _with_basics(names: list[str]) -> list[str]:
+    seen = set(names)
+    return list(names) + [land for land in BASIC_LANDS if land not in seen]
+
+
 def write_card_file(
     draft_set_code: str,
     names: list[str],
@@ -153,12 +161,16 @@ def write_card_file(
 ) -> int:
     """Write (or validate) the set-level card attribute parquet.
 
-    On first call: fetches MTGJSON and writes the card file from `names`.
-    On subsequent calls with the same names: validates and returns 1.
+    Basic lands are always included: they appear in every set's game data but
+    not always in draft packs (the `names_from_parquet` source) or the card
+    ratings API, so the card file's name set is canonicalized to include them
+    regardless of caller. On first call: fetches MTGJSON and writes the card
+    file. On subsequent calls with the same names: validates and returns 1.
     On subsequent calls with different names: raises ValueError — run
-    `spells refresh {set_code}` to regenerate.
-    With force_download=True: always overwrites.
+    `spells refresh {set_code}` to regenerate. With force_download=True:
+    always overwrites.
     """
+    names = _with_basics(names)
     mode = "refresh" if force_download else "add"
     card_filepath = cache.data_file_path(draft_set_code, View.CARD)
 

--- a/spells/cards.py
+++ b/spells/cards.py
@@ -146,12 +146,7 @@ def names_from_parquet(draft_set_code: str, event_type: EventType) -> list[str]:
     return [col[len(prefix):] for col in columns if col.startswith(prefix)]
 
 
-BASIC_LANDS = ("Plains", "Island", "Swamp", "Mountain", "Forest")
-
-
-def _with_basics(names: list[str]) -> list[str]:
-    seen = set(names)
-    return list(names) + [land for land in BASIC_LANDS if land not in seen]
+BASIC_LANDS = frozenset({"Plains", "Island", "Swamp", "Mountain", "Forest"})
 
 
 def write_card_file(
@@ -170,7 +165,7 @@ def write_card_file(
     `spells refresh {set_code}` to regenerate. With force_download=True:
     always overwrites.
     """
-    names = _with_basics(names)
+    names = list(set(names) | BASIC_LANDS)
     mode = "refresh" if force_download else "add"
     card_filepath = cache.data_file_path(draft_set_code, View.CARD)
 

--- a/tests/external_test.py
+++ b/tests/external_test.py
@@ -78,24 +78,42 @@ def test_add_pick_two_skips_only_set_context(record_io):
 
 
 def test_write_card_file_validates_consistent_names(tmp_path, monkeypatch):
-    from spells import cache
-    from spells.cards import write_card_file
+    from spells.cards import BASIC_LANDS, write_card_file
 
     monkeypatch.setenv("SPELLS_DATA_HOME", str(tmp_path))
     ext = tmp_path / "external" / "TST"
     ext.mkdir(parents=True)
-    pl.DataFrame({"name": ["Card A", "Card B"]}).write_parquet(ext / "TST_card.parquet")
+    pl.DataFrame({"name": ["Card A", "Card B", *BASIC_LANDS]}).write_parquet(
+        ext / "TST_card.parquet"
+    )
 
     assert write_card_file("TST", ["Card A", "Card B"]) == 1
 
 
-def test_write_card_file_raises_on_inconsistent_names(tmp_path, monkeypatch):
-    from spells.cards import write_card_file
+def test_write_card_file_tolerates_names_without_basics(tmp_path, monkeypatch):
+    from spells.cards import BASIC_LANDS, write_card_file
 
     monkeypatch.setenv("SPELLS_DATA_HOME", str(tmp_path))
     ext = tmp_path / "external" / "TST"
     ext.mkdir(parents=True)
-    pl.DataFrame({"name": ["Card A", "Card B"]}).write_parquet(ext / "TST_card.parquet")
+    pl.DataFrame({"name": ["Card A", *BASIC_LANDS]}).write_parquet(
+        ext / "TST_card.parquet"
+    )
+
+    # the card ratings API omits basics; the file still validates because
+    # write_card_file canonicalizes the incoming names to include them
+    assert write_card_file("TST", ["Card A"]) == 1
+
+
+def test_write_card_file_raises_on_inconsistent_names(tmp_path, monkeypatch):
+    from spells.cards import BASIC_LANDS, write_card_file
+
+    monkeypatch.setenv("SPELLS_DATA_HOME", str(tmp_path))
+    ext = tmp_path / "external" / "TST"
+    ext.mkdir(parents=True)
+    pl.DataFrame({"name": ["Card A", "Card B", *BASIC_LANDS]}).write_parquet(
+        ext / "TST_card.parquet"
+    )
 
     with pytest.raises(ValueError, match="inconsistent"):
         write_card_file("TST", ["Card A", "Card C"])


### PR DESCRIPTION
## Problem

Basic lands appear in every set's game data but **not** always in draft packs (the `names_from_parquet` source) nor in the card ratings API response. So the same set could end up with a card file that includes basics or omits them, depending on which path wrote it first. `card_ratings_view` (API path, no basics) would then fail `write_card_file`'s strict name-set equality check against a card file that a parquet ingest (`spells add`) had written **with** basics:

```
ValueError: Card list for SOS is inconsistent with existing file
(added=[], removed=['Forest', 'Island', 'Mountain', 'Plains', 'Swamp']).
```

This blocks any set that has both API-path (deq) and parquet-path (research) usage.

## Fix

`write_card_file` canonicalizes the incoming name set to always include the five basic lands before both the consistency check and the build. Every card file now carries basics regardless of caller, so the two paths agree.

Extra rows are harmless by design: the output row universe is always driven by the data source (the API agg frame for `card_ratings_view`, or the game/draft parquet for `summon`), with the card file used only as a name-keyed attribute lookup. The strict check still catches the genuinely dangerous case — a card the *data* references but the file lacks (`added` non-empty).

## Tests

- Updated the two existing `write_card_file` tests to reflect the basics-inclusive contract.
- Added `test_write_card_file_tolerates_names_without_basics` capturing the deq scenario directly (API omits basics, file has them → validates).
- Full suite: 87 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)