### PR TITLE
Stop card_ratings_view from touching the card file

### DIFF
--- a/spells/cards.py
+++ b/spells/cards.py
@@ -185,6 +185,7 @@ def write_card_file(
 
     cache.spells_print(mode, "Fetching card data from mtgjson.com and writing card file")
     df = card_df(draft_set_code, names)
+    os.makedirs(os.path.dirname(card_filepath), exist_ok=True)
     df.write_parquet(card_filepath)
     cache.spells_print(mode, f"Wrote file {card_filepath}")
     return 0

--- a/spells/draft_data.py
+++ b/spells/draft_data.py
@@ -687,12 +687,6 @@ def card_ratings_view(
                 cache_usage=cache_usage,
             )
             names = agg_df[ColName.NAME].to_list()
-            try:
-                write_card_file(code, names)
-            except ValueError:
-                raise  # card list inconsistency — propagate
-            except Exception:
-                pass  # MTGJSON unavailable (e.g. new set on release day)
 
             col_def_map = _hydrate_col_defs(
                 code,


### PR DESCRIPTION
## Bug

`card_ratings_view` called `write_card_file(code, names)` as an unconditional side effect on every call, despite never using its output — `card_only=True` already makes `_hydrate_col_defs` skip card-file hydration entirely, and the CARD_ATTR columns this view actually exposes (color, rarity, image_url) come straight from the `/api/card_data` response (`ratings_col_defs` in `card_data_files.py`).

Worse, that dead call silently broke for any set fetched only through the live API path and never through `spells add` (e.g. MSH): `write_card_file`'s write branch assumed its target directory already existed — true when `download_data_set` created it first, false here — so `df.write_parquet(...)` raised `FileNotFoundError`. That got caught by `card_ratings_view`'s broad `except Exception: pass` (there for "MTGJSON doesn't have this set yet"), so the failure was completely invisible.

## Fix

- Removed the `write_card_file` call from `card_ratings_view` — it was never load-bearing for this path.
- `write_card_file` now creates its target directory before writing, so it doesn't silently depend on a caller having done that already. Still matters for its one genuine caller (`summon()`'s attribute-hydration path) and for the new `spells add/refresh --card-only` commands (#25), which call it without a prior `download_data_set` in the same run.

## Tests

- Full suite: 96 passed, including the existing `test_no_parquet_files_needed`, which now passes because no attempt is made (previously it happened to pass because the attempt silently failed).
- Manual repro in an isolated temp data home: reproduced the original `FileNotFoundError`, confirmed the directory-creation fix resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)