### PR TITLE
Keep the 17Lands ratings API private to the package

### DIFF
--- a/spells/__init__.py
+++ b/spells/__init__.py
@@ -2,7 +2,7 @@ import logging
 
 from spells.columns import ColSpec
 from spells.enums import ColType, ColName, EventType, TimePeriod
-from spells.draft_data import summon, lazy_select, get_names, card_ratings_view
+from spells.draft_data import summon, lazy_select, get_names
 from spells.draft_model import (
     Draft,
     DraftCard,
@@ -19,7 +19,6 @@ __all__ = [
     "summon",
     "lazy_select",
     "get_names",
-    "card_ratings_view",
     "fetch_draft",
     "draft_from_public_data",
     "draft_view_df",

--- a/spells/card_data_files.py
+++ b/spells/card_data_files.py
@@ -1,6 +1,15 @@
+"""Live queries against 17Lands' curated aggregate endpoints.
+
+Unlike the public datasets (CC BY 4.0), this data is covered by 17Lands' usage
+guidelines: it is intended for use on 17Lands.com, automated access is
+discouraged without explicit permission, and derived work carries citation and
+new-set embargo obligations. Nothing here is exported from the package root.
+"""
+
 import datetime as dt
 from enum import StrEnum
 import json
+import logging
 import os
 from pathlib import Path
 import wget
@@ -70,6 +79,26 @@ deck_color_col_defs = {
 }
 
 
+_guidelines_warned = False
+
+
+def _warn_usage_guidelines() -> None:
+    """Warn once per process, on the first request that actually reaches
+    17Lands' servers. Cache hits are not requests, so they stay quiet."""
+    global _guidelines_warned
+    if _guidelines_warned:
+        return
+    _guidelines_warned = True
+
+    logging.warning(
+        "Fetching curated data from 17Lands. This data is not covered by the "
+        "CC BY 4.0 license that applies to the public datasets: 17Lands "
+        "discourages automated access without explicit permission, and asks "
+        "that published work cite 17Lands and observe the new-set embargo. "
+        "See 17lands.com/usage_guidelines and 17lands.com/terms_of_service."
+    )
+
+
 def download_data_file(url: str, target_dir: str, filename: str) -> str:
     """Download a 17lands data file unless already cached; return the local path."""
     if not os.path.isdir(target_dir):
@@ -133,6 +162,7 @@ def _fetch_snapshot(url: str, target_dir: str, filename: str, as_of: dt.date) ->
             "cannot be fetched"
         )
 
+    _warn_usage_guidelines()
     download_data_file(url, target_dir, filename)
     payload = _unwrap_payload(json.loads(Path(file_path).read_text()))
     if not payload:

--- a/tests/card_ratings_view_test.py
+++ b/tests/card_ratings_view_test.py
@@ -24,11 +24,13 @@ snapshot is most recently cached, however old).
 
 import datetime
 import json
+import logging
 from pathlib import Path
 
 import polars as pl
 import pytest
 
+from spells import card_data_files
 from spells.card_data_files import base_ratings_df, CacheUsage
 from spells.draft_data import card_ratings_view
 from spells.columns import ColSpec
@@ -358,3 +360,56 @@ def test_past_cache_usage_date_cache_miss_cannot_refetch(fake_ratings_file):
             time_period=TimePeriod.LAST_WEEK,
             cache_usage=FAKE_AS_OF,
         )
+
+
+# ---------------------------------------------------------------------------
+# Usage guidelines warning
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def unwarned():
+    """The warning fires once per process, so tests must clear the flag."""
+    card_data_files._guidelines_warned = False
+    yield
+    card_data_files._guidelines_warned = False
+
+
+@pytest.fixture
+def fake_download(monkeypatch):
+    monkeypatch.setattr(
+        "spells.card_data_files.wget.download",
+        lambda url, out: Path(out).write_text(json.dumps(FAKE_CARD_RATINGS)),
+    )
+
+
+def test_fetch_warns_about_usage_guidelines(
+    fake_ratings_file, fake_download, unwarned, caplog
+):
+    with caplog.at_level(logging.WARNING):
+        card_ratings_view(FAKE_SET, columns=["num_gih"], group_by=["name"])
+
+    assert "17lands.com/usage_guidelines" in caplog.text
+
+
+def test_cached_read_does_not_warn(fake_ratings_file, unwarned, caplog):
+    with caplog.at_level(logging.WARNING):
+        card_ratings_view(
+            FAKE_SET, columns=["num_gih"], group_by=["name"], cache_usage=FAKE_AS_OF
+        )
+
+    assert "usage_guidelines" not in caplog.text
+
+
+def test_warns_once_per_process(fake_ratings_file, fake_download, unwarned, caplog):
+    # distinct time periods are distinct snapshots, so both calls fetch
+    with caplog.at_level(logging.WARNING):
+        for time_period in (TimePeriod.LAST_WEEK, TimePeriod.LAST_TWO_WEEKS):
+            card_ratings_view(
+                FAKE_SET,
+                columns=["num_gih"],
+                group_by=["name"],
+                time_period=time_period,
+            )
+
+    assert caplog.text.count("usage_guidelines") == 1


### PR DESCRIPTION
Removes `card_ratings_view` from the package root and logs 17Lands' usage guidelines on live fetches.

## Why

17Lands' usage guidelines draw a line spells wasn't reflecting:

- The **public datasets** (the S3 dumps `spells add` downloads) are explicitly *out of scope* for the guidelines and released under CC BY 4.0 — the sanctioned source.
- The **curated aggregate endpoints** (`/api/card_data`, `/color_ratings/data`) are covered by the guidelines: automated access is discouraged without explicit permission, and derived work carries citation and new-set embargo obligations. The response envelope says so itself.

DEq is a sanctioned exception, and `card_data_files.py` exists for that case. The gray area was that spells *advertised* the capability to every user of the package. This keeps it available but unadvertised.

## Changes

**`card_ratings_view` off the package root** — dropped from `__init__.py` imports and `__all__`. Nothing deleted; callers use `from spells.draft_data import card_ratings_view`. The existing test suite already imported it that way.

**Usage-guidelines warning**, once per process, on the first request that actually reaches 17Lands' servers. Two placement notes:

- It sits in `_fetch_snapshot`, not `download_data_file` — the latter is shared with `fetch_draft`, and individual draft logs are explicitly *out of scope* for the guidelines ("data that is specific to an individual user").
- Cache hits don't warn, since they aren't requests. Relevant for DEq's nightly cron, which re-reads cached snapshots constantly.

**Module docstring** on `card_data_files.py`, which had none, stating the constraint for anyone reading the code.

## Tests

99 pass, up from 96. Three added: warns on fetch, silent on cache hit, once per process (the last uses two `TimePeriod` values so both calls genuinely fetch).

## Coordination

deq pulls `spells-mtg` from PyPI, so it's unaffected until the next release — but `deq/deq/main.py:7` imports `card_ratings_view` from the root and needs the same-cycle fix.

## Not addressed

Two pre-existing lint issues left alone to keep the diff focused: an unused `re` import in `cards.py`, and 14 files that aren't `ruff format` clean (including untouched regions of both files here).

---

First step of the spells CLI file-management work; full plan in `.claude/plans/spells-cli-file-management.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)