### PR TITLE
Rebuild the CLI on typer, backed by a data-home scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Spells is not affiliated with 17Lands. Please review the [Usage Guidelines](http
 - Can aggregate over multiple sets at once, even all of them, if you want.
 - Supports "Deck Color Data" aggregations with built-in column definitions.
 - Lets you feed card metrics back in to column definitions to support scientific workflows like MLE
-- Provides a CLI tool `spells [add|refresh|clean|remove|info] [SET]` to download and manage external files
+- Provides a CLI tool `spells [status|add|refresh|clean|remove|path] [SET]` to download and manage external files
 - Downloads and manages public datasets from 17Lands
 - Retrieves and models booster configuration and card data from [MTGJSON](https://mtgjson.com/)
 - Is fully typed, linted, and statically analyzed for support of advanced IDE features
@@ -274,7 +274,20 @@ So that's it, that's what Spells does from a high level. `summon` will hand off 
 
 Spells includes a command-line interface `spells` to manage your external data files and local cache. Spells will download files to an appropriate file location on your system, 
 typically `~/.local/share/spells` on Unix-like platforms and `C:\Users\{Username}\AppData\Local\Spells` on Windows, or to a location specified by the environment variable `SPELLS_DATA_HOME`.
-To use `spells`, make sure Spells is installed in your environment using pip or a package manager, and type `spells help` into your shell, or dive in with `spells add DSK` or your favorite set. If Spells is installed globally using pipx, any local version of Spells will be able to read the managed files.
+To use `spells`, make sure Spells is installed in your environment using pip or a package manager, and type `spells --help` into your shell, or dive in with `spells add DSK` or your favorite set. If Spells is installed globally using pipx, any local version of Spells will be able to read the managed files.
+
+Run `spells` with no arguments for an overview of everything on disk — which sets you have, which event types are complete, how much space each is using, and anything that looks wrong (leftover downloads, caches with no data behind them, files spells doesn't recognize). Pass a set code for detail on one set, or `--json` for machine-readable output.
+
+| command | |
+|---|---|
+| `spells status [SET]` | what is on disk, and anything wrong with it |
+| `spells add SET [EVENT_TYPE]` | download draft, game, and card files, skipping any already present |
+| `spells refresh SET [EVENT_TYPE]` | re-download and overwrite. Use sparingly |
+| `spells remove SET` | delete a set's downloaded data and derived cache |
+| `spells clean SET\|all` | delete derived cache files. Always safe: they rebuild on demand |
+| `spells path [SET] [--kind]` | print a data path, for scripting |
+
+`add` and `refresh` take `--card-only` to build or check the card file against draft data already on disk, without downloading. `remove` requires `--yes` when run unattended, so a script can never hang on a confirmation prompt.
 
 ## API
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,10 +5,21 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:ea9a63404bf91482f3acd1b2840cfe484b04c6186addb288807ea85a1345f9d1"
+content_hash = "sha256:fed85b456326cd21410e4a1ae381fe9600de77a3cea255b9b1bc888387a08c1a"
 
 [[metadata.targets]]
-requires_python = ">=3.11"
+requires_python = ">=3.13"
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+requires_python = ">=3.8"
+summary = "Document parameters, class attributes, return types, and variables inline, with Annotated."
+groups = ["default"]
+files = [
+    {file = "annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320"},
+    {file = "annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4"},
+]
 
 [[package]]
 name = "anyio"
@@ -299,8 +310,8 @@ name = "colorama"
 version = "0.4.6"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 summary = "Cross-platform colored terminal text."
-groups = ["dev"]
-marker = "sys_platform == \"win32\""
+groups = ["default", "dev"]
+marker = "sys_platform == \"win32\" or platform_system == \"Windows\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -1052,6 +1063,20 @@ files = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+requires_python = ">=3.10"
+summary = "Python port of markdown-it. Markdown parsing, done right!"
+groups = ["default"]
+dependencies = [
+    "mdurl~=0.1",
+]
+files = [
+    {file = "markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a"},
+    {file = "markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49"},
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.2"
 requires_python = ">=3.9"
@@ -1158,6 +1183,17 @@ dependencies = [
 files = [
     {file = "matplotlib_inline-0.1.7-py3-none-any.whl", hash = "sha256:df192d39a4ff8f21b1895d72e6a13f5fcc5099f00fa84384e0ea28c2cc0653ca"},
     {file = "matplotlib_inline-0.1.7.tar.gz", hash = "sha256:8423b23ec666be3d16e16b60bdd8ac4e86e840ebd1dd11a30b9f117f2fa0ab90"},
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+requires_python = ">=3.7"
+summary = "Markdown URL utilities"
+groups = ["default"]
+files = [
+    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
 ]
 
 [[package]]
@@ -1558,7 +1594,7 @@ name = "pygments"
 version = "2.18.0"
 requires_python = ">=3.8"
 summary = "Pygments is a syntax highlighting package written in Python."
-groups = ["dev"]
+groups = ["default", "dev"]
 files = [
     {file = "pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a"},
     {file = "pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199"},
@@ -1807,6 +1843,21 @@ files = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+requires_python = ">=3.9.0"
+summary = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+groups = ["default"]
+dependencies = [
+    "markdown-it-py>=2.2.0",
+    "pygments<3.0.0,>=2.13.0",
+]
+files = [
+    {file = "rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb"},
+    {file = "rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36"},
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.22.3"
 requires_python = ">=3.9"
@@ -1915,6 +1966,17 @@ groups = ["dev"]
 files = [
     {file = "setuptools-75.6.0-py3-none-any.whl", hash = "sha256:ce74b49e8f7110f9bf04883b730f4765b774ef3ef28f722cce7c273d253aaf7d"},
     {file = "setuptools-75.6.0.tar.gz", hash = "sha256:8199222558df7c86216af4f84c30e9b34a61d8ba19366cc914424cdbd28252f6"},
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+requires_python = ">=3.7"
+summary = "Tool to Detect Surrounding Shell"
+groups = ["default"]
+files = [
+    {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
+    {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
 ]
 
 [[package]]
@@ -2027,6 +2089,23 @@ files = [
 ]
 
 [[package]]
+name = "typer"
+version = "0.27.0"
+requires_python = ">=3.10"
+summary = "Typer, build great CLIs. Easy to code. Based on Python type hints."
+groups = ["default"]
+dependencies = [
+    "annotated-doc>=0.0.2",
+    "colorama; platform_system == \"Windows\"",
+    "rich>=13.8.0",
+    "shellingham>=1.3.0",
+]
+files = [
+    {file = "typer-0.27.0-py3-none-any.whl", hash = "sha256:6f4b27631e47f077871b7dc30e933ec0131c1390fbe0e387ea5574b5bac9ccf1"},
+    {file = "typer-0.27.0.tar.gz", hash = "sha256:629bd12ea5d13a17148125d9a264f949eb171fb3f120f9b04d85873cab054fa5"},
+]
+
+[[package]]
 name = "types-python-dateutil"
 version = "2.9.0.20241206"
 requires_python = ">=3.8"
@@ -2035,18 +2114,6 @@ groups = ["dev"]
 files = [
     {file = "types_python_dateutil-2.9.0.20241206-py3-none-any.whl", hash = "sha256:e248a4bc70a486d3e3ec84d0dc30eec3a5f979d6e7ee4123ae043eedbb987f53"},
     {file = "types_python_dateutil-2.9.0.20241206.tar.gz", hash = "sha256:18f493414c26ffba692a72369fea7a154c502646301ebfe3d56a04b3767284cb"},
-]
-
-[[package]]
-name = "typing-extensions"
-version = "4.12.2"
-requires_python = ">=3.8"
-summary = "Backported and Experimental Type Hints for Python 3.8+"
-groups = ["dev"]
-marker = "python_version < \"3.13\""
-files = [
-    {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
-    {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,14 @@ authors = [
 dependencies = [
     "polars==1.22.0",
     "wget>=3.2",
+    "typer>=0.27.0",
 ]
 requires-python = ">=3.13"
 readme = "README.md"
 license = {text = "MIT"}
 
 [project.scripts]
-spells = "spells.external:cli"
+spells = "spells.cli:app"
 
 [build-system]
 requires = ["pdm-backend"]

--- a/spells/cli.py
+++ b/spells/cli.py
@@ -1,0 +1,323 @@
+"""cli tool `spells`"""
+
+import json
+import sys
+from typing import Annotated
+
+import typer
+from rich.console import Console
+from rich.padding import Padding
+from rich.table import Table
+
+from spells import cache, external, inventory
+from spells.cache import DataDir
+from spells.enums import EventType
+from spells.inventory import Anomaly, AnomalyKind, Inventory
+
+ANOMALY_HELP = {
+    AnomalyKind.STRAY_DOWNLOAD: "leftover download artifacts",
+    AnomalyKind.LEGACY_CONTEXT: "pre-event_type context files",
+    AnomalyKind.LEGACY_SNAPSHOT: "pre-0.14 snapshots, unreadable today",
+    AnomalyKind.ORPHAN_CACHE: "cache with no data to rebuild from",
+    AnomalyKind.ORPHAN_DIR: "directories spells does not write",
+    AnomalyKind.UNKNOWN_FILE: "unrecognized files",
+    AnomalyKind.INCOMPLETE_SET: "sets missing dataset files",
+}
+
+app = typer.Typer(
+    help="Manage 17Lands public datasets, card files, and local caches.",
+    no_args_is_help=False,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+
+console = Console()
+err_console = Console(stderr=True)
+
+
+# Fred Cirera via https://stackoverflow.com/questions/1094841/get-a-human-readable-version-of-a-file-size
+def sizeof_fmt(num: float, suffix: str = "B") -> str:
+    for unit in ("", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"):
+        if abs(num) < 1024.0:
+            return f"{num:3.1f}{unit}{suffix}"
+        num /= 1024.0
+    return f"{num:.1f}Yi{suffix}"
+
+
+def _confirm(action: str, yes: bool) -> None:
+    """Destructive operations confirm on a terminal and refuse when piped, so
+    an unattended caller can never be left hanging on a prompt."""
+    if yes:
+        return
+    if not sys.stdin.isatty():
+        err_console.print(
+            f"Refusing to {action} without confirmation. Re-run with --yes."
+        )
+        raise typer.Exit(2)
+    if not typer.confirm(f"{action[0].upper()}{action[1:]}?"):
+        raise typer.Exit(2)
+
+
+def _anomaly_dict(anomaly: Anomaly) -> dict:
+    return {
+        "kind": str(anomaly.kind),
+        "path": str(anomaly.path),
+        "detail": anomaly.detail,
+        "set_code": anomaly.set_code,
+        "bytes": anomaly.size,
+    }
+
+
+def _inventory_dict(inv: Inventory, sets: list) -> dict:
+    """Explicit rather than dataclasses.asdict: this is the `--json` contract,
+    and it should not drift every time the dataclasses are refactored."""
+    return {
+        "data_home": str(inv.data_home),
+        "total_bytes": inv.total_bytes,
+        "draft_logs": inv.draft_logs,
+        "sets": [
+            {
+                "set_code": s.set_code,
+                "event_types": {
+                    str(event): {
+                        "complete": files.is_complete,
+                        "missing": list(files.missing),
+                    }
+                    for event, files in s.events.items()
+                },
+                "card_file": s.card_file is not None,
+                "external_bytes": s.external_bytes,
+                "cache_files": s.cache_files,
+                "cache_bytes": s.cache_bytes,
+                "ratings": {
+                    "valid": s.ratings.valid,
+                    "legacy": s.ratings.legacy,
+                    "bytes": s.ratings.total_bytes,
+                },
+                "deck_color": {
+                    "valid": s.deck_color.valid,
+                    "legacy": s.deck_color.legacy,
+                    "bytes": s.deck_color.total_bytes,
+                },
+                "anomalies": [_anomaly_dict(a) for a in s.anomalies],
+            }
+            for s in sets
+        ],
+        "anomalies": [_anomaly_dict(a) for a in inv.anomalies],
+    }
+
+
+def _event_summary(set_inv) -> str:
+    if not set_inv.events:
+        return "[dim]—[/dim]"
+    parts = []
+    for event, files in set_inv.events.items():
+        if files.is_complete:
+            parts.append(str(event))
+        else:
+            parts.append(f"[yellow]{event} (no {', '.join(files.missing)})[/yellow]")
+    return "\n".join(parts)
+
+
+def _snapshot_summary(set_inv) -> str:
+    valid = set_inv.ratings.valid + set_inv.deck_color.valid
+    legacy = set_inv.ratings.legacy + set_inv.deck_color.legacy
+    if not valid and not legacy:
+        return "[dim]—[/dim]"
+    text = f"{valid}"
+    if legacy:
+        text += f" [yellow]+{legacy} old[/yellow]"
+    return text
+
+
+def _render_status(
+    inv: Inventory, sets: list, anomalies: list[Anomaly], detailed: bool
+) -> None:
+    console.print(
+        f"  🪄 [bold]spells[/bold] ✨ {inv.data_home} "
+        f"[dim]({sizeof_fmt(inv.total_bytes)})[/dim]\n"
+    )
+
+    if not sets:
+        console.print("  [dim]No data found. Try `spells add DSK`.[/dim]")
+        return
+
+    table = Table(box=None, pad_edge=False, header_style="bold")
+    table.add_column("set")
+    table.add_column("external", justify="right")
+    table.add_column("cards", justify="center")
+    table.add_column("cache", justify="right")
+    table.add_column("snapshots", justify="right")
+    table.add_column("event types")
+
+    for s in sets:
+        table.add_row(
+            s.set_code,
+            sizeof_fmt(s.external_bytes) if s.external_bytes else "[dim]—[/dim]",
+            "✓" if s.card_file else "[dim]—[/dim]",
+            str(s.cache_files) if s.cache_files else "[dim]—[/dim]",
+            _snapshot_summary(s),
+            _event_summary(s),
+        )
+
+    console.print(Padding(table, (0, 0, 0, 2)))
+
+    if inv.draft_logs:
+        console.print(
+            f"\n  {inv.draft_logs} cached draft logs "
+            f"[dim]({sizeof_fmt(inv.draft_log_bytes)})[/dim]"
+        )
+
+    if not anomalies:
+        return
+
+    console.print(f"\n[bold]issues[/bold] ({len(anomalies)})")
+
+    if detailed:
+        for a in anomalies:
+            size = f" [dim]{sizeof_fmt(a.size)}[/dim]" if a.size else ""
+            # soft_wrap keeps long paths on one line for copy-paste
+            console.print(
+                f"  [yellow]{a.kind}[/yellow]{size} — {a.detail}", soft_wrap=True
+            )
+            console.print(f"    [dim]{a.path}[/dim]", soft_wrap=True)
+        return
+
+    summary = Table(box=None, pad_edge=False, show_header=False)
+    summary.add_column(style="yellow")
+    summary.add_column(justify="right")
+    summary.add_column(justify="right")
+    summary.add_column(style="dim")
+
+    for kind in AnomalyKind:
+        matching = [a for a in anomalies if a.kind == kind]
+        if not matching:
+            continue
+        size = sum(a.size for a in matching)
+        summary.add_row(
+            str(kind),
+            str(len(matching)),
+            sizeof_fmt(size) if size else "—",
+            ANOMALY_HELP[kind],
+        )
+
+    console.print(Padding(summary, (0, 0, 0, 2)))
+    console.print("\n  [dim]`spells status <SET>` for detail[/dim]")
+
+
+@app.callback(invoke_without_command=True)
+def main(ctx: typer.Context) -> None:
+    if ctx.invoked_subcommand is None:
+        status()
+
+
+@app.command()
+def status(
+    set_code: Annotated[
+        str | None, typer.Argument(help="Limit to a single set.")
+    ] = None,
+    json_out: Annotated[
+        bool, typer.Option("--json", help="Machine-readable output.")
+    ] = False,
+) -> None:
+    """Show what is on disk and anything that looks wrong with it."""
+    inv = inventory.scan()
+
+    sets = list(inv.sets.values())
+    anomalies = inv.all_anomalies
+
+    if set_code is not None:
+        sets = [s for s in sets if s.set_code == set_code]
+        if not sets:
+            err_console.print(f"No data found for set {set_code}")
+            raise typer.Exit(1)
+        anomalies = sets[0].anomalies
+
+    if json_out:
+        print(json.dumps(_inventory_dict(inv, sets), indent=2))
+        return
+
+    _render_status(inv, sets, anomalies, detailed=set_code is not None)
+
+
+@app.command(hidden=True)
+def info() -> None:
+    """Deprecated alias for `status`."""
+    status()
+
+
+@app.command()
+def add(
+    set_code: str,
+    event_type: Annotated[EventType, typer.Argument()] = EventType.PREMIER,
+    card_only: Annotated[
+        bool,
+        typer.Option(
+            "--card-only",
+            help="Spot-check the card file against draft data already on disk.",
+        ),
+    ] = False,
+) -> None:
+    """Download draft, game, and card files, skipping any already present."""
+    if card_only:
+        raise typer.Exit(external._add_card_only(set_code, event_type=event_type))
+    raise typer.Exit(external._add(set_code, event_type=event_type))
+
+
+@app.command()
+def refresh(
+    set_code: str,
+    event_type: Annotated[EventType, typer.Argument()] = EventType.PREMIER,
+    card_only: Annotated[
+        bool,
+        typer.Option(
+            "--card-only",
+            help="Rebuild only the card file, from draft data already on disk.",
+        ),
+    ] = False,
+) -> None:
+    """Re-download and overwrite existing files. Use sparingly."""
+    if card_only:
+        raise typer.Exit(external._refresh_card_only(set_code, event_type=event_type))
+    raise typer.Exit(external._refresh(set_code, event_type=event_type))
+
+
+@app.command()
+def remove(
+    set_code: str,
+    yes: Annotated[
+        bool, typer.Option("--yes", "-y", help="Skip confirmation.")
+    ] = False,
+) -> None:
+    """Delete a set's downloaded data and its derived cache."""
+    _confirm(f"delete all downloaded data for {set_code}", yes)
+    raise typer.Exit(external._remove(set_code))
+
+
+@app.command()
+def clean(
+    set_code: Annotated[str, typer.Argument(help='A set code, or "all".')],
+) -> None:
+    """Delete derived cache files. Always safe: they rebuild on demand."""
+    raise typer.Exit(cache.clean(set_code))
+
+
+@app.command()
+def path(
+    set_code: Annotated[str | None, typer.Argument()] = None,
+    kind: Annotated[
+        DataDir | None, typer.Option("--kind", help="Which store to report.")
+    ] = None,
+) -> None:
+    """Print a data path, for scripting."""
+    if kind is None:
+        target = cache.external_set_path(set_code) if set_code else cache.data_home()
+    elif set_code:
+        target = f"{cache.data_dir_path(kind)}/{set_code}"
+    else:
+        target = cache.data_dir_path(kind)
+
+    print(target)
+
+
+def cli() -> None:
+    app()

--- a/spells/external.py
+++ b/spells/external.py
@@ -1,16 +1,11 @@
 """
 download public data sets from 17Lands.com and generate a card
 file containing card attributes using MTGJSON
-
-cli tool `spells`
 """
 
-import functools
 import gzip
 import os
-import re
 import shutil
-import sys
 from enum import StrEnum
 
 import wget
@@ -32,116 +27,6 @@ RESOURCE_TEMPLATE = (
 class FileFormat(StrEnum):
     CSV = "csv"
     PARQUET = "parquet"
-
-
-# Fred Cirera via https://stackoverflow.com/questions/1094841/get-a-human-readable-version-of-a-file-size
-def sizeof_fmt(num, suffix="B"):
-    for unit in ("", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"):
-        if abs(num) < 1024.0:
-            return f"{num:3.1f}{unit}{suffix}"
-        num /= 1024.0
-    return f"{num:.1f}Yi{suffix}"
-
-
-def cli() -> int:
-    data_dir = cache.data_home()
-    cache.spells_print("spells", f"[data home]={data_dir}")
-    print()
-    usage = """spells [add|refresh|remove|clean] [set_code] [event_type]
-            spells [add|refresh] [set_code] --card-only [event_type]
-            spells clean all
-            spells info
-
-    add: Download draft and game files from 17Lands.com and card file from MTGJSON.com and save to path
-        [data home]/external/[set code] (use $SPELLS_DATA_HOME or $XDG_DATA_HOME to configure).
-        Does not overwrite existing files. If any files are downloaded, existing local cache is cleared.
-        [set code] should be the capitalized official set code for the draft release.
-
-        e.g. $ spells add OTJ
-
-        [event_type] is optional and defaults to PremierDraft. Pass a 17Lands event type
-        (e.g. PickTwoDraft) to download an alternate draft format. The draft, game, and
-        card downloads are format-agnostic; only the set context (and summon) are not
-        supported for multi-pick formats yet.
-
-        e.g. $ spells add OM1 PickTwoDraft
-
-        --card-only: spot-check the card file against the draft file already on
-        disk — no download. Builds the card file if missing; if it exists and
-        disagrees with the draft file's names, raises rather than overwriting.
-
-        e.g. $ spells add OTJ --card-only
-
-    refresh: Force download and overwrite of existing files (for new data drops, use sparingly!). Clear
-        local
-
-        --card-only: rebuild just the card file, from the draft file already on disk —
-        no download. For when the card file itself needs fixing (e.g. after a spells
-        release changes how it's built) but the draft/game data is still good.
-
-        e.g. $ spells refresh OTJ --card-only
-
-    remove: Delete the [data home]/external/[set code] and [data home]/local/[set code] directories and their contents
-
-    clean: Delete [data home]/local/[set code] data directory (your cache of aggregate parquet files), or all of them.
-
-    info: No set code argument. Print info on all external and local files.
-    """
-    print_usage = functools.partial(cache.spells_print, "usage", usage)
-
-    args = [a for a in sys.argv[1:] if a != "--card-only"]
-    card_only = len(args) != len(sys.argv) - 1
-
-    if len(args) < 1:
-        print_usage()
-        return 1
-
-    mode = args[0]
-
-    if mode == "info":
-        return _info()
-
-    if card_only and mode not in ("add", "refresh"):
-        cache.spells_print(
-            "usage", "--card-only is only valid with `spells add`/`spells refresh`"
-        )
-        return 1
-
-    if len(args) not in (2, 3):
-        print_usage()
-        return 1
-
-    set_code = args[1]
-
-    if len(args) == 3:
-        try:
-            event_type = EventType(args[2])
-        except ValueError:
-            cache.spells_print(
-                "usage",
-                f"Unknown event type '{args[2]}'; expected one of "
-                f"{[e.value for e in EventType]}",
-            )
-            return 1
-    else:
-        event_type = EventType.PREMIER
-
-    match mode:
-        case "add":
-            if card_only:
-                return _add_card_only(set_code, event_type=event_type)
-            return _add(set_code, event_type=event_type)
-        case "refresh":
-            if card_only:
-                return _refresh_card_only(set_code, event_type=event_type)
-            return _refresh(set_code, event_type=event_type)
-        case "remove":
-            return _remove(set_code)
-        case "clean":
-            return cache.clean(set_code)
-        case _:
-            print_usage()
-            return 1
 
 
 def _add(
@@ -233,75 +118,6 @@ def _remove(set_code: str):
         cache.spells_print(mode, f"No external cache found for set {set_code}")
 
     return cache.clean(set_code)
-
-
-def _info():
-    mode = "info"
-    external_path = cache.data_dir_path(cache.DataDir.EXTERNAL)
-
-    suggest_add = set()
-    suggest_remove = set()
-    all_external = set()
-    if os.path.isdir(external_path):
-        cache.spells_print(mode, f"External archives found {external_path}")
-        with os.scandir(external_path) as ext_dir:
-            for entry in ext_dir:
-                if entry.is_dir():
-                    all_external.add(entry.name)
-                    file_count = 0
-                    cache.spells_print(mode, f"Archive {entry.name} contents:")
-                    for item in os.scandir(entry):
-                        if not re.match(f"^{entry.name}_.*\\.parquet", item.name):
-                            print(
-                                f"!!! imposter file {item.name}! Please sort that out"
-                            )
-                        print(f"    {item.name} {sizeof_fmt(os.stat(item).st_size)}")
-                        file_count += 1
-                    if file_count < 4:
-                        suggest_add.add(entry.name)
-                    if file_count > 4:
-                        suggest_remove.add(entry.name)
-                else:
-                    cache.spells_print(
-                        mode, f"Imposter file {entry.name}! Please sort that out"
-                    )
-
-    else:
-        cache.spells_print(mode, "No external archives found")
-
-    cache_path = cache.data_dir_path(cache.DataDir.CACHE)
-
-    if os.path.isdir(cache_path):
-        print()
-        cache.spells_print(mode, f"Local cache found {cache_path}")
-        with os.scandir(cache_path) as cache_dir:
-            for entry in cache_dir:
-                if entry.name not in all_external:
-                    suggest_remove.add(entry.name)
-                if entry.is_dir():
-                    cache.spells_print(mode, f"Cache {entry.name} contents:")
-                    parquet_num = 0
-                    parquet_size = 0
-                    for item in os.scandir(entry):
-                        if item.name.endswith(".parquet"):
-                            parquet_num += 1
-                            parquet_size += os.stat(item).st_size
-                        else:
-                            print(
-                                f"!!! imposter file {item.name}! Please sort that out"
-                            )
-                    print(f"    {parquet_num} cache files: {sizeof_fmt(parquet_size)}")
-    else:
-        print()
-        cache.spells_print(mode, "No local cache found")
-
-    print()
-    for name in suggest_add:
-        cache.spells_print(mode, f"Suggest `spells add {name}'")
-    for name in suggest_remove:
-        cache.spells_print(mode, f"Suggest `spells remove {name}'")
-
-    return 0
 
 
 def _process_zipped_file(gzip_path, target_path):

--- a/spells/inventory.py
+++ b/spells/inventory.py
@@ -1,0 +1,344 @@
+"""What is on disk, and what looks wrong with it.
+
+A single scan of the data home feeds every reporting command: `status`,
+`snapshots`, and `doctor` are renderings of the same `Inventory`, not
+independent directory walks. Nothing here writes, deletes, or reaches the
+network.
+"""
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+import os
+from pathlib import Path
+import re
+
+from spells import cache
+from spells.cache import DataDir
+from spells.enums import EventType, TimePeriod
+
+# {set}_{event_type}_{view}.parquet, and the set-level {set}_card.parquet
+DATASET_VIEWS = ("draft", "game", "context")
+
+# 17lands snapshots are {query stub}_{as_of}.json. The pre-0.14 scheme encoded a
+# {start}_{end} date range instead of a time period, and nothing can read those.
+_SNAPSHOT_RE = re.compile(r"^(?P<stub>.+)_(?P<as_of>\d{4}-\d{2}-\d{2})\.json$")
+
+# created by log.setup_logging, not a data store
+_LOG_DIR = ".logs"
+
+KNOWN_DIRS = frozenset({*(d.value for d in DataDir), "ad_hoc", _LOG_DIR})
+
+
+class AnomalyKind(StrEnum):
+    STRAY_DOWNLOAD = "stray-download"
+    LEGACY_CONTEXT = "legacy-context"
+    LEGACY_SNAPSHOT = "legacy-snapshot"
+    ORPHAN_CACHE = "orphan-cache"
+    ORPHAN_DIR = "orphan-dir"
+    UNKNOWN_FILE = "unknown-file"
+    INCOMPLETE_SET = "incomplete-set"
+
+
+@dataclass(frozen=True)
+class Anomaly:
+    kind: AnomalyKind
+    path: Path
+    detail: str
+    set_code: str | None = None
+    size: int = 0
+
+
+@dataclass(frozen=True)
+class FileInfo:
+    path: Path
+    size: int
+
+
+@dataclass(frozen=True)
+class EventFiles:
+    event_type: EventType
+    draft: FileInfo | None = None
+    game: FileInfo | None = None
+    context: FileInfo | None = None
+
+    @property
+    def missing(self) -> tuple[str, ...]:
+        # summon skips set context for multi-pick formats, so pick-two sets are
+        # complete without one.
+        expected = ("draft", "game") if self.is_pick_two else DATASET_VIEWS
+        return tuple(v for v in expected if getattr(self, v) is None)
+
+    @property
+    def is_pick_two(self) -> bool:
+        return self.event_type == EventType.PICK_TWO
+
+    @property
+    def is_complete(self) -> bool:
+        return not self.missing
+
+
+@dataclass(frozen=True)
+class SnapshotStats:
+    valid: int = 0
+    valid_bytes: int = 0
+    legacy: int = 0
+    legacy_bytes: int = 0
+
+    @property
+    def total(self) -> int:
+        return self.valid + self.legacy
+
+    @property
+    def total_bytes(self) -> int:
+        return self.valid_bytes + self.legacy_bytes
+
+
+@dataclass
+class SetInventory:
+    set_code: str
+    events: dict[EventType, EventFiles] = field(default_factory=dict)
+    card_file: FileInfo | None = None
+    external_bytes: int = 0
+    cache_files: int = 0
+    cache_bytes: int = 0
+    ratings: SnapshotStats = field(default_factory=SnapshotStats)
+    deck_color: SnapshotStats = field(default_factory=SnapshotStats)
+    anomalies: list[Anomaly] = field(default_factory=list)
+
+    @property
+    def has_external(self) -> bool:
+        return bool(self.events) or self.card_file is not None
+
+    @property
+    def snapshot_bytes(self) -> int:
+        return self.ratings.total_bytes + self.deck_color.total_bytes
+
+    @property
+    def total_bytes(self) -> int:
+        return self.external_bytes + self.cache_bytes + self.snapshot_bytes
+
+
+@dataclass
+class Inventory:
+    data_home: Path
+    sets: dict[str, SetInventory] = field(default_factory=dict)
+    draft_logs: int = 0
+    draft_log_bytes: int = 0
+    anomalies: list[Anomaly] = field(default_factory=list)
+
+    @property
+    def all_anomalies(self) -> list[Anomaly]:
+        return self.anomalies + [a for s in self.sets.values() for a in s.anomalies]
+
+    @property
+    def total_bytes(self) -> int:
+        return sum(s.total_bytes for s in self.sets.values()) + self.draft_log_bytes
+
+
+def is_valid_snapshot(filename: str) -> bool:
+    """A snapshot is current-scheme iff it ends in `_{time_period}_{as_of}.json`.
+
+    Parsing from the right avoids having to enumerate event types, cohorts, and
+    deck colors, and avoids assuming anything about set code punctuation
+    (`Cube+-+Powered` is a real set directory).
+    """
+    match = _SNAPSHOT_RE.match(filename)
+    if match is None:
+        return False
+    stub = match.group("stub")
+    return any(stub.endswith(f"_{period}") for period in TimePeriod)
+
+
+def _file_info(entry: os.DirEntry) -> FileInfo:
+    return FileInfo(path=Path(entry.path), size=entry.stat().st_size)
+
+
+def _scan_external_set(inv: SetInventory, set_dir: Path) -> None:
+    events: dict[EventType, dict[str, FileInfo]] = {}
+
+    with os.scandir(set_dir) as entries:
+        for entry in entries:
+            info = _file_info(entry)
+            inv.external_bytes += info.size
+
+            if not entry.name.endswith(".parquet"):
+                inv.anomalies.append(
+                    Anomaly(
+                        AnomalyKind.STRAY_DOWNLOAD,
+                        info.path,
+                        "leftover download artifact, not a dataset",
+                        inv.set_code,
+                        info.size,
+                    )
+                )
+                continue
+
+            stem = entry.name[: -len(".parquet")]
+            if not stem.startswith(f"{inv.set_code}_"):
+                inv.anomalies.append(
+                    Anomaly(
+                        AnomalyKind.UNKNOWN_FILE,
+                        info.path,
+                        f"does not belong to set {inv.set_code}",
+                        inv.set_code,
+                        info.size,
+                    )
+                )
+                continue
+
+            rest = stem[len(inv.set_code) + 1 :]
+            if rest == "card":
+                inv.card_file = info
+                continue
+
+            event_type, _, view = rest.rpartition("_")
+            if view in DATASET_VIEWS and event_type in tuple(EventType):
+                events.setdefault(EventType(event_type), {})[view] = info
+            elif rest in DATASET_VIEWS:
+                inv.anomalies.append(
+                    Anomaly(
+                        AnomalyKind.LEGACY_CONTEXT,
+                        info.path,
+                        f"pre-event_type {rest} file, superseded by "
+                        f"{inv.set_code}_<event_type>_{rest}.parquet",
+                        inv.set_code,
+                        info.size,
+                    )
+                )
+            else:
+                inv.anomalies.append(
+                    Anomaly(
+                        AnomalyKind.UNKNOWN_FILE,
+                        info.path,
+                        "unrecognized dataset name",
+                        inv.set_code,
+                        info.size,
+                    )
+                )
+
+    for event_type, views in sorted(events.items()):
+        inv.events[event_type] = EventFiles(event_type=event_type, **views)
+
+    for event_files in inv.events.values():
+        if missing := event_files.missing:
+            inv.anomalies.append(
+                Anomaly(
+                    AnomalyKind.INCOMPLETE_SET,
+                    set_dir,
+                    f"{event_files.event_type} is missing {', '.join(missing)}",
+                    inv.set_code,
+                )
+            )
+
+
+def _scan_snapshots(inv: SetInventory, set_dir: Path, store: DataDir) -> SnapshotStats:
+    valid = valid_bytes = legacy = legacy_bytes = 0
+
+    with os.scandir(set_dir) as entries:
+        for entry in entries:
+            info = _file_info(entry)
+            if is_valid_snapshot(entry.name):
+                valid += 1
+                valid_bytes += info.size
+            else:
+                legacy += 1
+                legacy_bytes += info.size
+
+    # one anomaly per store, not per file — these run to thousands, and the
+    # paths are cheap to re-derive when something actually acts on them
+    if legacy:
+        inv.anomalies.append(
+            Anomaly(
+                AnomalyKind.LEGACY_SNAPSHOT,
+                set_dir,
+                f"{legacy} pre-0.14 {store} snapshots, unreadable by any "
+                "current code path",
+                inv.set_code,
+                legacy_bytes,
+            )
+        )
+
+    return SnapshotStats(valid, valid_bytes, legacy, legacy_bytes)
+
+
+def _scan_cache_set(inv: SetInventory, set_dir: Path) -> None:
+    with os.scandir(set_dir) as entries:
+        for entry in entries:
+            info = _file_info(entry)
+            if entry.name.endswith(".parquet"):
+                inv.cache_files += 1
+                inv.cache_bytes += info.size
+            else:
+                inv.anomalies.append(
+                    Anomaly(
+                        AnomalyKind.UNKNOWN_FILE,
+                        info.path,
+                        "not a cache file",
+                        inv.set_code,
+                        info.size,
+                    )
+                )
+
+
+def _set_dirs(store: DataDir) -> list[Path]:
+    store_path = Path(cache.data_dir_path(store))
+    if not store_path.is_dir():
+        return []
+    return sorted(p for p in store_path.iterdir() if p.is_dir())
+
+
+def scan() -> Inventory:
+    """Walk the data home once and classify everything in it."""
+    home = Path(cache.data_home())
+    inventory = Inventory(data_home=home)
+
+    def set_inv(set_code: str) -> SetInventory:
+        return inventory.sets.setdefault(set_code, SetInventory(set_code=set_code))
+
+    for set_dir in _set_dirs(DataDir.EXTERNAL):
+        _scan_external_set(set_inv(set_dir.name), set_dir)
+
+    for set_dir in _set_dirs(DataDir.CACHE):
+        _scan_cache_set(set_inv(set_dir.name), set_dir)
+
+    for store, attr in (
+        (DataDir.RATINGS, "ratings"),
+        (DataDir.DECK_COLOR, "deck_color"),
+    ):
+        for set_dir in _set_dirs(store):
+            inv = set_inv(set_dir.name)
+            setattr(inv, attr, _scan_snapshots(inv, set_dir, store))
+
+    for inv in inventory.sets.values():
+        if inv.cache_files and not inv.has_external:
+            inv.anomalies.append(
+                Anomaly(
+                    AnomalyKind.ORPHAN_CACHE,
+                    Path(cache.cache_dir_for_set(inv.set_code)),
+                    "derived cache with no external data to rebuild it from",
+                    inv.set_code,
+                    inv.cache_bytes,
+                )
+            )
+
+    draft_dir = Path(cache.data_dir_path(DataDir.DRAFT))
+    if draft_dir.is_dir():
+        logs = [p for p in draft_dir.iterdir() if p.is_file()]
+        inventory.draft_logs = len(logs)
+        inventory.draft_log_bytes = sum(p.stat().st_size for p in logs)
+
+    if home.is_dir():
+        for entry in sorted(home.iterdir()):
+            if entry.is_dir() and entry.name not in KNOWN_DIRS:
+                size = sum(p.stat().st_size for p in entry.rglob("*") if p.is_file())
+                inventory.anomalies.append(
+                    Anomaly(
+                        AnomalyKind.ORPHAN_DIR,
+                        entry,
+                        "not a store spells writes to",
+                        size=size,
+                    )
+                )
+
+    inventory.sets = dict(sorted(inventory.sets.items()))
+    return inventory

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1,0 +1,184 @@
+"""
+Tests for the `spells` command line. CliRunner drives the real typer app; the
+download orchestration is monkeypatched, so nothing reaches the network.
+
+Note that CliRunner's stdin is never a tty, which is exactly the unattended
+case the destructive commands have to refuse rather than hang on.
+"""
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from spells import cli, external
+from spells.enums import EventType
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def data_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("SPELLS_DATA_HOME", str(tmp_path))
+    (tmp_path / "external" / "TST").mkdir(parents=True)
+    for view in ("draft", "game", "context"):
+        (
+            tmp_path / "external" / "TST" / f"TST_PremierDraft_{view}.parquet"
+        ).write_bytes(b"x" * 10)
+    (tmp_path / "external" / "TST" / "TST_card.parquet").write_bytes(b"x" * 10)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# status
+# ---------------------------------------------------------------------------
+
+
+def test_bare_invocation_shows_status(data_home):
+    result = runner.invoke(cli.app, [])
+    assert result.exit_code == 0
+    assert "TST" in result.stdout
+
+
+def test_status_json_is_parseable(data_home):
+    result = runner.invoke(cli.app, ["status", "--json"])
+    assert result.exit_code == 0
+
+    payload = json.loads(result.stdout)
+    assert payload["data_home"] == str(data_home)
+    (entry,) = payload["sets"]
+    assert entry["set_code"] == "TST"
+    assert entry["card_file"] is True
+    assert entry["event_types"]["PremierDraft"]["complete"] is True
+
+
+def test_status_for_one_set(data_home):
+    assert runner.invoke(cli.app, ["status", "TST"]).exit_code == 0
+
+
+def test_status_for_unknown_set_exits_1(data_home):
+    result = runner.invoke(cli.app, ["status", "NOPE"])
+    assert result.exit_code == 1
+
+
+def test_status_reports_anomalies(data_home):
+    (data_home / "external" / "ECL").mkdir(parents=True)
+    (
+        data_home / "external" / "ECL" / "draft_data_public.ECL.PremierDraft.csv"
+    ).write_bytes(b"x" * 10)
+
+    result = runner.invoke(cli.app, ["status"])
+    assert "stray-download" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# add / refresh dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_add_card_only_dispatches(monkeypatch, data_home):
+    calls = []
+    monkeypatch.setattr(
+        external,
+        "_add_card_only",
+        lambda set_code, event_type: calls.append((set_code, event_type)) or 0,
+    )
+    monkeypatch.setattr(external, "_add", lambda *a, **kw: pytest.fail("full add ran"))
+
+    result = runner.invoke(cli.app, ["add", "TST", "--card-only"])
+    assert result.exit_code == 0
+    assert calls == [("TST", EventType.PREMIER)]
+
+
+def test_refresh_card_only_dispatches(monkeypatch, data_home):
+    calls = []
+    monkeypatch.setattr(
+        external,
+        "_refresh_card_only",
+        lambda set_code, event_type: calls.append((set_code, event_type)) or 0,
+    )
+    monkeypatch.setattr(
+        external, "_refresh", lambda *a, **kw: pytest.fail("full refresh ran")
+    )
+
+    result = runner.invoke(cli.app, ["refresh", "TST", "--card-only"])
+    assert result.exit_code == 0
+    assert calls == [("TST", EventType.PREMIER)]
+
+
+def test_add_passes_event_type(monkeypatch, data_home):
+    calls = []
+    monkeypatch.setattr(
+        external, "_add", lambda set_code, event_type: calls.append(event_type) or 0
+    )
+
+    runner.invoke(cli.app, ["add", "OM1", "PickTwoDraft"])
+    assert calls == [EventType.PICK_TWO]
+
+
+def test_add_rejects_unknown_event_type(data_home):
+    result = runner.invoke(cli.app, ["add", "TST", "NotARealDraft"])
+    assert result.exit_code == 2
+
+
+def test_card_only_is_not_accepted_by_remove(data_home):
+    result = runner.invoke(cli.app, ["remove", "TST", "--card-only"])
+    assert result.exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# Destructive commands and headless behavior
+# ---------------------------------------------------------------------------
+
+
+def test_remove_refuses_without_confirmation_when_piped(monkeypatch, data_home):
+    monkeypatch.setattr(external, "_remove", lambda *a: pytest.fail("removed anyway"))
+
+    result = runner.invoke(cli.app, ["remove", "TST"])
+    assert result.exit_code == 2
+
+
+def test_remove_proceeds_with_yes(monkeypatch, data_home):
+    calls = []
+    monkeypatch.setattr(
+        external, "_remove", lambda set_code: calls.append(set_code) or 0
+    )
+
+    result = runner.invoke(cli.app, ["remove", "TST", "--yes"])
+    assert result.exit_code == 0
+    assert calls == ["TST"]
+
+
+def test_clean_is_not_gated(data_home):
+    # derived cache rebuilds on demand, so it never needs confirmation
+    (data_home / "cache" / "TST").mkdir(parents=True)
+    (data_home / "cache" / "TST" / "abc.parquet").write_bytes(b"x" * 10)
+
+    result = runner.invoke(cli.app, ["clean", "TST"])
+    assert result.exit_code == 0
+    assert not (data_home / "cache" / "TST").exists()
+
+
+# ---------------------------------------------------------------------------
+# path
+# ---------------------------------------------------------------------------
+
+
+def test_path_reports_data_home(data_home):
+    result = runner.invoke(cli.app, ["path"])
+    assert result.stdout.strip() == str(data_home)
+
+
+def test_path_reports_external_set_dir(data_home):
+    result = runner.invoke(cli.app, ["path", "TST"])
+    assert result.stdout.strip() == str(data_home / "external" / "TST")
+
+
+def test_path_reports_store_dir(data_home):
+    result = runner.invoke(cli.app, ["path", "--kind", "ratings"])
+    assert result.stdout.strip() == str(data_home / "ratings")
+
+
+def test_path_reports_store_set_dir(data_home):
+    result = runner.invoke(cli.app, ["path", "TST", "--kind", "cache"])
+    assert result.stdout.strip() == str(data_home / "cache" / "TST")

--- a/tests/external_test.py
+++ b/tests/external_test.py
@@ -155,40 +155,6 @@ def test_add_card_only_requires_existing_draft_file(monkeypatch):
     assert external._add_card_only("TST", event_type=EventType.PREMIER) == 1
 
 
-def test_cli_dispatches_refresh_card_only(monkeypatch):
-    calls = []
-    monkeypatch.setattr(
-        external,
-        "_refresh_card_only",
-        lambda set_code, event_type: calls.append((set_code, event_type)) or 0,
-    )
-    monkeypatch.setattr(external, "_refresh", lambda *a, **kw: pytest.fail("full refresh ran"))
-    monkeypatch.setattr(external.sys, "argv", ["spells", "refresh", "TST", "--card-only"])
-
-    assert external.cli() == 0
-    assert calls == [("TST", EventType.PREMIER)]
-
-
-def test_cli_dispatches_add_card_only(monkeypatch):
-    calls = []
-    monkeypatch.setattr(
-        external,
-        "_add_card_only",
-        lambda set_code, event_type: calls.append((set_code, event_type)) or 0,
-    )
-    monkeypatch.setattr(external, "_add", lambda *a, **kw: pytest.fail("full add ran"))
-    monkeypatch.setattr(external.sys, "argv", ["spells", "add", "TST", "--card-only"])
-
-    assert external.cli() == 0
-    assert calls == [("TST", EventType.PREMIER)]
-
-
-def test_cli_rejects_card_only_with_remove(monkeypatch):
-    monkeypatch.setattr(external.sys, "argv", ["spells", "remove", "TST", "--card-only"])
-
-    assert external.cli() == 1
-
-
 def test_write_card_file_validates_consistent_names(tmp_path, monkeypatch):
     from spells.cards import BASIC_LANDS, write_card_file
 

--- a/tests/inventory_test.py
+++ b/tests/inventory_test.py
@@ -1,0 +1,268 @@
+"""
+Tests for the data-home scanner. Everything runs against a fabricated data
+home in tmp_path — no network, no real files.
+
+The snapshot classifier gets the most attention: Phase 2's prune deletes
+whatever it calls legacy, and a false positive there destroys data that cannot
+be refetched (17lands resolves time periods against its own current date).
+"""
+
+import json
+
+import pytest
+
+from spells import inventory
+from spells.enums import EventType, TimePeriod
+from spells.inventory import AnomalyKind, is_valid_snapshot
+
+
+@pytest.fixture
+def data_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("SPELLS_DATA_HOME", str(tmp_path))
+    return tmp_path
+
+
+def write_external(home, set_code, *names):
+    d = home / "external" / set_code
+    d.mkdir(parents=True, exist_ok=True)
+    for name in names:
+        (d / name).write_bytes(b"x" * 10)
+    return d
+
+
+def write_snapshots(home, store, set_code, *names):
+    d = home / store / set_code
+    d.mkdir(parents=True, exist_ok=True)
+    for name in names:
+        (d / name).write_text(json.dumps([{"name": "Card A"}]))
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Snapshot classifier
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("period", list(TimePeriod))
+def test_every_time_period_is_valid(period):
+    assert is_valid_snapshot(f"PremierDraft_all_any_{period}_2026-07-14.json")
+
+
+@pytest.mark.parametrize("period", list(TimePeriod))
+def test_deck_color_shape_is_valid(period):
+    # deck_color snapshots have no deck-color token
+    assert is_valid_snapshot(f"PremierDraft_top_{period}_2026-07-14.json")
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "PremierDraft_all_any_2026-06-23_2026-06-24.json",
+        "PremierDraft_top_2024-09-07_2024-09-07.json",
+        "PremierDraft_top_BRG_2024-10-08_2025-10-14 (1).json",
+        "PremierDraft_all_any_ALL_TIME.json",
+        "PremierDraft_all_any_NOT_A_PERIOD_2026-07-14.json",
+        "notes.txt",
+    ],
+)
+def test_legacy_and_junk_are_not_valid(name):
+    assert not is_valid_snapshot(name)
+
+
+def test_punctuated_set_codes_do_not_confuse_the_classifier():
+    # `Cube+-+Powered` is a real set directory; set code never appears in the
+    # filename, but guard against a future regex that assumes [A-Z]{3}
+    assert is_valid_snapshot(
+        f"PremierDraft_all_any_{TimePeriod.ALL_TIME}_2026-07-14.json"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scanning
+# ---------------------------------------------------------------------------
+
+
+def test_empty_data_home(data_home):
+    inv = inventory.scan()
+    assert inv.sets == {}
+    assert inv.all_anomalies == []
+
+
+def test_complete_premier_set(data_home):
+    write_external(
+        data_home,
+        "TST",
+        "TST_card.parquet",
+        "TST_PremierDraft_draft.parquet",
+        "TST_PremierDraft_game.parquet",
+        "TST_PremierDraft_context.parquet",
+    )
+    inv = inventory.scan()
+
+    tst = inv.sets["TST"]
+    assert tst.card_file is not None
+    assert tst.events[EventType.PREMIER].is_complete
+    assert tst.anomalies == []
+
+
+def test_incomplete_set_is_flagged(data_home):
+    write_external(
+        data_home, "TST", "TST_card.parquet", "TST_PremierDraft_draft.parquet"
+    )
+    inv = inventory.scan()
+
+    (anomaly,) = inv.sets["TST"].anomalies
+    assert anomaly.kind == AnomalyKind.INCOMPLETE_SET
+    assert "game" in anomaly.detail and "context" in anomaly.detail
+
+
+def test_pick_two_set_is_complete_without_context(data_home):
+    # summon skips set context for multi-pick formats
+    write_external(
+        data_home,
+        "OM1",
+        "OM1_card.parquet",
+        "OM1_PickTwoDraft_draft.parquet",
+        "OM1_PickTwoDraft_game.parquet",
+    )
+    inv = inventory.scan()
+
+    assert inv.sets["OM1"].events[EventType.PICK_TWO].is_complete
+    assert inv.sets["OM1"].anomalies == []
+
+
+def test_multiple_event_types(data_home):
+    write_external(
+        data_home,
+        "SOS",
+        "SOS_card.parquet",
+        *[
+            f"SOS_{event}_{view}.parquet"
+            for event in (EventType.PREMIER, EventType.TRADITIONAL)
+            for view in ("draft", "game", "context")
+        ],
+    )
+    inv = inventory.scan()
+
+    sos = inv.sets["SOS"]
+    assert set(sos.events) == {EventType.PREMIER, EventType.TRADITIONAL}
+    assert all(e.is_complete for e in sos.events.values())
+    assert sos.anomalies == []
+
+
+def test_stray_download_is_flagged(data_home):
+    write_external(
+        data_home,
+        "ECL",
+        "ECL_PremierDraft_draft.parquet",
+        "draft_data_public.ECL.PremierDraft.csv",
+    )
+    inv = inventory.scan()
+
+    kinds = {a.kind for a in inv.sets["ECL"].anomalies}
+    assert AnomalyKind.STRAY_DOWNLOAD in kinds
+
+
+def test_legacy_context_file_is_flagged(data_home):
+    write_external(
+        data_home,
+        "TDM",
+        "TDM_card.parquet",
+        "TDM_context.parquet",
+        "TDM_PremierDraft_draft.parquet",
+        "TDM_PremierDraft_game.parquet",
+        "TDM_PremierDraft_context.parquet",
+    )
+    inv = inventory.scan()
+
+    legacy = [
+        a for a in inv.sets["TDM"].anomalies if a.kind == AnomalyKind.LEGACY_CONTEXT
+    ]
+    assert len(legacy) == 1
+
+
+def test_legacy_snapshots_aggregate_to_one_anomaly(data_home):
+    write_snapshots(
+        data_home,
+        "ratings",
+        "BLB",
+        *[
+            f"PremierDraft_all_any_2024-08-13_2024-09-{d:02d}.json"
+            for d in range(10, 30)
+        ],
+        f"PremierDraft_all_any_{TimePeriod.ALL_TIME}_2026-07-14.json",
+    )
+    inv = inventory.scan()
+
+    blb = inv.sets["BLB"]
+    assert blb.ratings.valid == 1
+    assert blb.ratings.legacy == 20
+
+    (anomaly,) = blb.anomalies
+    assert anomaly.kind == AnomalyKind.LEGACY_SNAPSHOT
+    assert "20" in anomaly.detail
+
+
+def test_orphan_cache_is_flagged(data_home):
+    cache_dir = data_home / "cache" / "GONE"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "abc123.parquet").write_bytes(b"x" * 10)
+
+    inv = inventory.scan()
+
+    kinds = {a.kind for a in inv.sets["GONE"].anomalies}
+    assert AnomalyKind.ORPHAN_CACHE in kinds
+
+
+def test_cache_with_external_data_is_not_orphaned(data_home):
+    write_external(data_home, "TST", "TST_card.parquet")
+    cache_dir = data_home / "cache" / "TST"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "abc123.parquet").write_bytes(b"x" * 10)
+
+    inv = inventory.scan()
+
+    kinds = {a.kind for a in inv.sets["TST"].anomalies}
+    assert AnomalyKind.ORPHAN_CACHE not in kinds
+
+
+def test_orphan_top_level_dir_is_flagged(data_home):
+    (data_home / "filters").mkdir(parents=True)
+    (data_home / "filters" / "filters_2026-07-03.json").write_text("{}")
+
+    inv = inventory.scan()
+
+    (anomaly,) = inv.anomalies
+    assert anomaly.kind == AnomalyKind.ORPHAN_DIR
+    assert anomaly.path.name == "filters"
+
+
+def test_log_dir_is_not_an_anomaly(data_home):
+    (data_home / ".logs").mkdir(parents=True)
+    (data_home / ".logs" / "spells.log").write_text("")
+
+    assert inventory.scan().anomalies == []
+
+
+def test_draft_logs_are_counted(data_home):
+    draft_dir = data_home / "draft"
+    draft_dir.mkdir(parents=True)
+    for i in range(3):
+        (draft_dir / f"{i}.json").write_text("{}")
+
+    inv = inventory.scan()
+    assert inv.draft_logs == 3
+
+
+def test_sets_are_unioned_across_stores(data_home):
+    write_external(data_home, "TST", "TST_card.parquet")
+    write_snapshots(
+        data_home,
+        "ratings",
+        "Cube+-+Powered",
+        f"PremierDraft_all_any_{TimePeriod.ALL_TIME}_2026-07-14.json",
+    )
+    inv = inventory.scan()
+
+    assert set(inv.sets) == {"TST", "Cube+-+Powered"}
+    assert not inv.sets["Cube+-+Powered"].has_external


### PR DESCRIPTION
## Summary
- Replace the hand-rolled `sys.argv` parser in `external.py` with a Typer-based CLI.
- Add `spells/inventory.py`: a pure, single-pass scanner of the data home that classifies what's on disk (per-event-type completeness, leftover download artifacts, orphaned caches, pre-0.14 snapshots, etc). `status`, `path`, and future reporting commands render this one scan instead of each doing their own directory walk.
- `add`/`refresh`/`remove`/`clean` keep existing behavior; orchestration stays in `external.py`.
- New: `status` (also the bare invocation) with `--json`, and `path` for scripting.
- Destructive commands confirm on a terminal and refuse when piped, except `clean`, which is always safe since caches rebuild on demand.

## Test plan
- [x] `pdm run pytest` passes locally
- [x] Manually exercised `status`, `status <set>`, `clean <set>`, `clean all`, `add <set>`, `path` against real data home