### PR TITLE
Add catalog-backed `spells check`, and move HTTP to requests

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:fed85b456326cd21410e4a1ae381fe9600de77a3cea255b9b1bc888387a08c1a"
+content_hash = "sha256:fe6310f6457838015ada16a013c1e07b44f00b379a6e49afbf96a7b08b795334"
 
 [[metadata.targets]]
 requires_python = ">=3.13"
@@ -202,7 +202,7 @@ name = "certifi"
 version = "2024.12.14"
 requires_python = ">=3.6"
 summary = "Python package for providing Mozilla's CA Bundle."
-groups = ["dev"]
+groups = ["default", "dev"]
 files = [
     {file = "certifi-2024.12.14-py3-none-any.whl", hash = "sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56"},
     {file = "certifi-2024.12.14.tar.gz", hash = "sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db"},
@@ -260,7 +260,7 @@ name = "charset-normalizer"
 version = "3.4.1"
 requires_python = ">=3.7"
 summary = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
-groups = ["dev"]
+groups = ["default", "dev"]
 files = [
     {file = "charset_normalizer-3.4.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:8bfa33f4f2672964266e940dd22a195989ba31669bd84629f05fab3ef4e2d125"},
     {file = "charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28bf57629c75e810b6ae989f03c0828d64d6b26a5e205535585f96093e405ed1"},
@@ -561,7 +561,7 @@ name = "idna"
 version = "3.10"
 requires_python = ">=3.6"
 summary = "Internationalized Domain Names in Applications (IDNA)"
-groups = ["dev"]
+groups = ["default", "dev"]
 files = [
     {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
     {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
@@ -1805,7 +1805,7 @@ name = "requests"
 version = "2.32.3"
 requires_python = ">=3.8"
 summary = "Python HTTP for Humans."
-groups = ["dev"]
+groups = ["default", "dev"]
 dependencies = [
     "certifi>=2017.4.17",
     "charset-normalizer<4,>=2",
@@ -2132,7 +2132,7 @@ name = "urllib3"
 version = "2.3.0"
 requires_python = ">=3.9"
 summary = "HTTP library with thread-safe connection pooling, file post, and more."
-groups = ["dev"]
+groups = ["default", "dev"]
 files = [
     {file = "urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df"},
     {file = "urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d"},
@@ -2181,15 +2181,6 @@ groups = ["dev"]
 files = [
     {file = "websocket_client-1.8.0-py3-none-any.whl", hash = "sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526"},
     {file = "websocket_client-1.8.0.tar.gz", hash = "sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da"},
-]
-
-[[package]]
-name = "wget"
-version = "3.2"
-summary = "pure python download utility"
-groups = ["default"]
-files = [
-    {file = "wget-3.2.zip", hash = "sha256:35e630eca2aa50ce998b9b1a127bb26b30dfee573702782aa982f875e3f16061"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 dependencies = [
     "polars==1.22.0",
-    "wget>=3.2",
+    "requests>=2.32",
     "typer>=0.27.0",
 ]
 requires-python = ">=3.13"

--- a/spells/card_data_files.py
+++ b/spells/card_data_files.py
@@ -12,12 +12,12 @@ import json
 import logging
 import os
 from pathlib import Path
-import wget
 from time import sleep
 
 import polars as pl
 
 from spells import cache
+from spells import http
 from spells.enums import ColName, EventType, TimePeriod
 
 RATINGS_TEMPLATE = (
@@ -107,7 +107,7 @@ def download_data_file(url: str, target_dir: str, filename: str) -> str:
     file_path = os.path.join(target_dir, filename)
 
     if not os.path.isfile(file_path):
-        wget.download(url, out=file_path)
+        http.download(url, file_path, progress=False)
 
     return file_path
 

--- a/spells/cards.py
+++ b/spells/cards.py
@@ -1,12 +1,11 @@
 import json
 import os
-import re
-import urllib.request
 from enum import StrEnum
 
 import polars as pl
 
 from spells import cache
+from spells import http
 from spells.enums import ColName, View, EventType
 
 
@@ -34,15 +33,7 @@ MTG_JSON_TEMPLATE = "https://mtgjson.com/api/v5/{set_code}.json"
 
 
 def _fetch_mtg_json(set_code: str) -> dict:
-    request = urllib.request.Request(
-        MTG_JSON_TEMPLATE.format(set_code=set_code),
-        headers={"User-Agent": "spells-mtg/0.1.0"},
-    )
-
-    with urllib.request.urlopen(request) as f:
-        draft_set_json = json.loads(f.read().decode("utf-8"))
-
-    return draft_set_json
+    return http.get_json(MTG_JSON_TEMPLATE.format(set_code=set_code))
 
 
 def _extract_value(set_code: str, name: str, card_dict: dict, field: CardAttr):

--- a/spells/catalog.py
+++ b/spells/catalog.py
@@ -1,0 +1,298 @@
+"""What 17Lands publishes, and whether our copy of it is current.
+
+The Public Datasets page is a Prismic CMS document, not a 17Lands API. That
+document is public and unauthenticated, and its hyperlink spans carry the
+canonical S3 URLs — so it is the sanctioned way to discover what exists, rather
+than guessing filenames from a template. Two things follow from using it:
+
+- It *enumerates*. S3 objects are `public-read` but the bucket is not listable,
+  so nothing else can answer "what sets could I add?" It also distinguishes
+  "not published" from "published and you don't have it" — old expansions have
+  no draft data at all, and requesting one returns 403.
+- It reports formats spells does not model (Sealed, TradSealed, QuickDraft).
+  Those are surfaced as unsupported rather than dropped, so `check` never
+  silently hides published data.
+
+The catalog's own `last_updated` field is hand-maintained and lags, so it is
+display-only. Freshness decisions come from a HEAD on the URL the catalog gives
+us. Nothing here writes to the data home.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from email.utils import parsedate_to_datetime
+from enum import StrEnum
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from spells.enums import EventType, View
+
+PRISMIC_API = "https://17lands.cdn.prismic.io/api/v2"
+PRISMIC_QUERY = '[[at(document.type,"public-data")]]'
+
+# Used when the catalog is unreachable. The catalog is authoritative when it
+# answers; these only keep `add` working offline-ish, and cannot enumerate.
+DATASET_TEMPLATE = "{dataset_type}_data_public.{set_code}.{event_type}.csv.gz"
+RESOURCE_TEMPLATE = (
+    "https://17lands-public.s3.amazonaws.com/analysis_data/{dataset_type}_data/"
+)
+
+USER_AGENT = "spells-mtg"
+TIMEOUT = 30
+
+
+class Freshness(StrEnum):
+    CURRENT = "current"
+    STALE = "stale"
+    ABSENT = "absent"
+    UNPUBLISHED = "unpublished"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class RemoteFile:
+    url: str
+    last_modified: datetime | None = None
+    etag: str | None = None
+    size: int | None = None
+
+
+@dataclass(frozen=True)
+class Dataset:
+    expansion: str
+    format_name: str
+    event_type: EventType | None
+    last_updated: date | None
+    draft_url: str | None
+    game_url: str | None
+
+    @property
+    def is_supported(self) -> bool:
+        return self.event_type is not None
+
+    def url(self, view: View) -> str | None:
+        return {View.DRAFT: self.draft_url, View.GAME: self.game_url}.get(view)
+
+
+@dataclass(frozen=True)
+class Catalog:
+    datasets: tuple[Dataset, ...]
+    is_fallback: bool = False
+
+    @property
+    def expansions(self) -> tuple[str, ...]:
+        return tuple(dict.fromkeys(d.expansion for d in self.datasets))
+
+    def for_expansion(self, expansion: str) -> tuple[Dataset, ...]:
+        return tuple(d for d in self.datasets if d.expansion == expansion)
+
+    def get(self, expansion: str, event_type: EventType) -> Dataset | None:
+        for dataset in self.datasets:
+            if dataset.expansion == expansion and dataset.event_type == event_type:
+                return dataset
+        return None
+
+
+def _text(field) -> str:
+    return "".join(block.get("text", "") for block in field or []).strip()
+
+
+def _link(field) -> str | None:
+    """A dataset that is not published renders as a literal "-" with no span."""
+    for block in field or []:
+        for span in block.get("spans", []):
+            if span.get("type") == "hyperlink":
+                if url := span.get("data", {}).get("url"):
+                    return url
+    return None
+
+
+def _event_type(format_name: str) -> EventType | None:
+    try:
+        return EventType(format_name)
+    except ValueError:
+        return None
+
+
+def _parse_date(text: str) -> date | None:
+    try:
+        return date.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def parse(document: dict) -> Catalog:
+    """Build a Catalog from a Prismic `public-data` document.
+
+    Kept separate from fetching so it can be tested against a saved response.
+    """
+    datasets = []
+    for entry in document.get("data", {}).get("datasets", []):
+        expansion = _text(entry.get("expansion"))
+        format_name = _text(entry.get("format"))
+        if not expansion or not format_name:
+            continue
+        datasets.append(
+            Dataset(
+                expansion=expansion,
+                format_name=format_name,
+                event_type=_event_type(format_name),
+                last_updated=_parse_date(_text(entry.get("last_updated"))),
+                draft_url=_link(entry.get("draft_data")),
+                game_url=_link(entry.get("game_data")),
+            )
+        )
+    return Catalog(datasets=tuple(datasets))
+
+
+def _get_json(url: str) -> dict:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(request, timeout=TIMEOUT) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _fetch_document() -> dict:
+    ref = _get_json(PRISMIC_API)["refs"][0]["ref"]
+    query = urllib.parse.urlencode({"ref": ref, "q": PRISMIC_QUERY, "pageSize": 100})
+    results = _get_json(f"{PRISMIC_API}/documents/search?{query}")["results"]
+    if not results:
+        raise ValueError("no public-data document in the 17Lands catalog")
+    return results[0]
+
+
+_cached: Catalog | None = None
+
+
+def fetch(refresh: bool = False) -> Catalog:
+    """The published catalog, memoized for the process lifetime.
+
+    Returns an empty fallback Catalog if 17Lands is unreachable; callers should
+    check `is_fallback` before reporting "not published".
+    """
+    global _cached
+    if _cached is not None and not refresh:
+        return _cached
+
+    try:
+        _cached = parse(_fetch_document())
+    except (
+        urllib.error.URLError,
+        TimeoutError,
+        KeyError,
+        ValueError,
+        json.JSONDecodeError,
+    ):
+        _cached = Catalog(datasets=(), is_fallback=True)
+    return _cached
+
+
+def fallback_url(expansion: str, view: View, event_type: EventType) -> str:
+    return RESOURCE_TEMPLATE.format(dataset_type=view) + DATASET_TEMPLATE.format(
+        dataset_type=view, set_code=expansion, event_type=event_type
+    )
+
+
+def head(url: str) -> RemoteFile | None:
+    """Remote metadata, or None if the object is missing or unreachable.
+
+    Unpublished datasets are `public-read` only for objects that exist, so a
+    stale or guessed URL comes back 403 rather than 404.
+    """
+    request = urllib.request.Request(
+        url, method="HEAD", headers={"User-Agent": USER_AGENT}
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=TIMEOUT) as response:
+            headers = response.headers
+    except (urllib.error.URLError, TimeoutError):
+        return None
+
+    last_modified = None
+    if raw := headers.get("Last-Modified"):
+        try:
+            last_modified = parsedate_to_datetime(raw)
+        except (TypeError, ValueError):
+            last_modified = None
+
+    size = None
+    if raw := headers.get("Content-Length"):
+        try:
+            size = int(raw)
+        except ValueError:
+            size = None
+
+    return RemoteFile(
+        url=url, last_modified=last_modified, etag=headers.get("ETag"), size=size
+    )
+
+
+@dataclass(frozen=True)
+class Target:
+    expansion: str
+    event_type: EventType
+    view: View
+    local_mtime: float | None = None
+
+
+@dataclass(frozen=True)
+class CheckRow:
+    target: Target
+    freshness: Freshness
+    remote: RemoteFile | None = None
+
+    @property
+    def needs_download(self) -> bool:
+        return self.freshness in (Freshness.STALE, Freshness.ABSENT)
+
+
+def resolve(
+    targets: list[Target], cat: Catalog, max_workers: int = 8
+) -> list[CheckRow]:
+    """Classify each target against the catalog, doing the HEADs concurrently.
+
+    Only datasets we already hold are HEADed: the catalog alone is enough to
+    say a missing one is published, and skipping those keeps `check` to one
+    request per file actually on disk.
+    """
+    rows: list[CheckRow] = []
+    to_head: list[tuple[Target, str]] = []
+
+    for target in targets:
+        dataset = cat.get(target.expansion, target.event_type)
+        url = dataset.url(target.view) if dataset else None
+        if url is None:
+            freshness = Freshness.UNKNOWN if cat.is_fallback else Freshness.UNPUBLISHED
+            rows.append(CheckRow(target, freshness))
+        elif target.local_mtime is None:
+            rows.append(CheckRow(target, Freshness.ABSENT, RemoteFile(url=url)))
+        else:
+            to_head.append((target, url))
+
+    if to_head:
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            remotes = pool.map(head, [url for _, url in to_head])
+        for (target, url), remote in zip(to_head, remotes):
+            rows.append(CheckRow(target, compare(target.local_mtime, remote), remote))
+
+    order = {t: i for i, t in enumerate(targets)}
+    return sorted(rows, key=lambda row: order[row.target])
+
+
+def compare(local_mtime: float | None, remote: RemoteFile | None) -> Freshness:
+    """Classify one local file against its published counterpart.
+
+    Compares against the local parquet's mtime, which is when we wrote it — a
+    conversion always postdates the download, so a local file newer than the
+    remote object is genuinely current.
+    """
+    if remote is None:
+        return Freshness.UNPUBLISHED if local_mtime is None else Freshness.UNKNOWN
+    if local_mtime is None:
+        return Freshness.ABSENT
+    if remote.last_modified is None:
+        return Freshness.UNKNOWN
+    local = datetime.fromtimestamp(local_mtime, tz=timezone.utc)
+    return Freshness.STALE if local < remote.last_modified else Freshness.CURRENT

--- a/spells/catalog.py
+++ b/spells/catalog.py
@@ -24,11 +24,11 @@ from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from email.utils import parsedate_to_datetime
 from enum import StrEnum
-import json
-import urllib.error
 import urllib.parse
-import urllib.request
 
+import requests
+
+from spells import http
 from spells.enums import EventType, View
 
 PRISMIC_API = "https://17lands.cdn.prismic.io/api/v2"
@@ -40,9 +40,6 @@ DATASET_TEMPLATE = "{dataset_type}_data_public.{set_code}.{event_type}.csv.gz"
 RESOURCE_TEMPLATE = (
     "https://17lands-public.s3.amazonaws.com/analysis_data/{dataset_type}_data/"
 )
-
-USER_AGENT = "spells-mtg"
-TIMEOUT = 30
 
 
 class Freshness(StrEnum):
@@ -161,16 +158,10 @@ def parse(document: dict) -> Catalog:
     return Catalog(datasets=tuple(datasets))
 
 
-def _get_json(url: str) -> dict:
-    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
-    with urllib.request.urlopen(request, timeout=TIMEOUT) as response:
-        return json.loads(response.read().decode("utf-8"))
-
-
 def _fetch_document() -> dict:
-    ref = _get_json(PRISMIC_API)["refs"][0]["ref"]
+    ref = http.get_json(PRISMIC_API)["refs"][0]["ref"]
     query = urllib.parse.urlencode({"ref": ref, "q": PRISMIC_QUERY, "pageSize": 100})
-    results = _get_json(f"{PRISMIC_API}/documents/search?{query}")["results"]
+    results = http.get_json(f"{PRISMIC_API}/documents/search?{query}")["results"]
     if not results:
         raise ValueError("no public-data document in the 17Lands catalog")
     return results[0]
@@ -191,13 +182,7 @@ def fetch(refresh: bool = False) -> Catalog:
 
     try:
         _cached = parse(_fetch_document())
-    except (
-        urllib.error.URLError,
-        TimeoutError,
-        KeyError,
-        ValueError,
-        json.JSONDecodeError,
-    ):
+    except (requests.RequestException, KeyError, ValueError):
         _cached = Catalog(datasets=(), is_fallback=True)
     return _cached
 
@@ -209,19 +194,11 @@ def fallback_url(expansion: str, view: View, event_type: EventType) -> str:
 
 
 def head(url: str) -> RemoteFile | None:
-    """Remote metadata, or None if the object is missing or unreachable.
-
-    Unpublished datasets are `public-read` only for objects that exist, so a
-    stale or guessed URL comes back 403 rather than 404.
-    """
-    request = urllib.request.Request(
-        url, method="HEAD", headers={"User-Agent": USER_AGENT}
-    )
-    try:
-        with urllib.request.urlopen(request, timeout=TIMEOUT) as response:
-            headers = response.headers
-    except (urllib.error.URLError, TimeoutError):
+    """Remote metadata, or None if the object is missing or unreachable."""
+    response = http.head(url)
+    if response is None:
         return None
+    headers = response.headers
 
     last_modified = None
     if raw := headers.get("Last-Modified"):

--- a/spells/catalog.py
+++ b/spells/catalog.py
@@ -18,7 +18,7 @@ display-only. Freshness decisions come from a HEAD on the URL the catalog gives
 us. Nothing here writes to the data home.
 """
 
-from collections.abc import Collection
+from collections.abc import Collection, Iterable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
@@ -294,6 +294,19 @@ def resolve(
     return sorted(rows, key=lambda row: order[row.target])
 
 
+def in_release_order(cat: Catalog, expansions: Iterable[str]) -> list[str]:
+    """Newest expansion first, by catalog array position.
+
+    17Lands authors the array in release order, which is the order a drafter
+    thinks in; alphabetical ordering puts whatever they are currently drafting
+    at an arbitrary place in the list. Expansions the catalog no longer lists
+    sort to the end alphabetically rather than vanishing.
+    """
+    order = {expansion: i for i, expansion in enumerate(cat.expansions)}
+    known = sorted((e for e in expansions if e in order), key=lambda e: -order[e])
+    return known + sorted(e for e in expansions if e not in order)
+
+
 def unadded(cat: Catalog, held: Collection[str]) -> list[str]:
     """Published expansions the caller does not have, newest first.
 
@@ -310,12 +323,14 @@ def unadded(cat: Catalog, held: Collection[str]) -> list[str]:
     position = {expansion: i for i, expansion in enumerate(order)}
     anchor = min((position[e] for e in held if e in position), default=0)
 
-    missing = [
-        expansion
-        for expansion in order[anchor:]
-        if expansion not in held and cat.is_addable(expansion)
-    ]
-    return list(reversed(missing))
+    return in_release_order(
+        cat,
+        (
+            expansion
+            for expansion in order[anchor:]
+            if expansion not in held and cat.is_addable(expansion)
+        ),
+    )
 
 
 def compare(local_mtime: float | None, remote: RemoteFile | None) -> Freshness:

--- a/spells/catalog.py
+++ b/spells/catalog.py
@@ -18,6 +18,7 @@ display-only. Freshness decisions come from a HEAD on the URL the catalog gives
 us. Nothing here writes to the data home.
 """
 
+from collections.abc import Collection
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
@@ -94,6 +95,18 @@ class Catalog:
             if dataset.expansion == expansion and dataset.event_type == event_type:
                 return dataset
         return None
+
+    def is_addable(self, expansion: str) -> bool:
+        """Whether any event type spells models has draft data published."""
+        return any(
+            d.is_supported and d.draft_url for d in self.for_expansion(expansion)
+        )
+
+    def updated(self, expansion: str) -> date | None:
+        dates = [
+            d.last_updated for d in self.for_expansion(expansion) if d.last_updated
+        ]
+        return max(dates) if dates else None
 
 
 def _text(field) -> str:
@@ -279,6 +292,30 @@ def resolve(
 
     order = {t: i for i, t in enumerate(targets)}
     return sorted(rows, key=lambda row: order[row.target])
+
+
+def unadded(cat: Catalog, held: Collection[str]) -> list[str]:
+    """Published expansions the caller does not have, newest first.
+
+    Anchored to the oldest expansion they already hold, so sets that predate
+    their collection are not reported as things they are missing. Without that
+    anchor the answer would be every expansion 17Lands has ever published,
+    which is noise rather than news.
+
+    Ordering comes from the catalog array, which 17Lands authors in release
+    order, rather than from `last_updated` — regenerating an old set's files
+    bumps that date without making the set new.
+    """
+    order = cat.expansions
+    position = {expansion: i for i, expansion in enumerate(order)}
+    anchor = min((position[e] for e in held if e in position), default=0)
+
+    missing = [
+        expansion
+        for expansion in order[anchor:]
+        if expansion not in held and cat.is_addable(expansion)
+    ]
+    return list(reversed(missing))
 
 
 def compare(local_mtime: float | None, remote: RemoteFile | None) -> Freshness:

--- a/spells/cli.py
+++ b/spells/cli.py
@@ -314,6 +314,8 @@ FRESHNESS_STYLE = {
 
 CHECKED_VIEWS = (View.DRAFT, View.GAME)
 
+UNADDED_SHOWN = 5
+
 
 def _targets(
     inv: Inventory, set_code: str | None, cat: catalog.Catalog
@@ -368,6 +370,7 @@ def _render_check(
     cat: catalog.Catalog,
     held: set[tuple[str, EventType]],
     detailed: bool,
+    unadded: list[str],
 ) -> None:
     if cat.is_fallback:
         err_console.print(
@@ -422,8 +425,21 @@ def _render_check(
             events = sorted({str(e) for evs in available.values() for e in evs})
             console.print(
                 f"\n  [dim]{len(available)} set(s) also publish "
-                f"{', '.join(events)} — `spells check <SET>` for detail[/dim]"
+                f"{', '.join(events)}[/dim]"
             )
+            console.print("  [dim]`spells check <SET>` for detail[/dim]")
+
+    if unadded:
+        shown = unadded[:UNADDED_SHOWN]
+        console.print(f"\n  [bold]published, not added[/bold] ({len(unadded)})")
+        for expansion in shown:
+            when = cat.updated(expansion)
+            console.print(
+                f"    [cyan]{expansion:<14}[/cyan] "
+                f"[dim]{when.isoformat() if when else '—'}[/dim]"
+            )
+        if len(unadded) > len(shown):
+            console.print(f"    [dim]+{len(unadded) - len(shown)} older[/dim]")
 
     work = sorted({r.target.expansion for r in tracked if _is_actionable(r, held)})
     if work:
@@ -456,6 +472,16 @@ def check(
     rows = catalog.resolve(_targets(inv, set_code, cat), cat)
     held = _held_events(inv)
 
+    # only meaningful for the whole-data-home view; naming a set already says
+    # which expansion you care about
+    unadded = (
+        []
+        if set_code is not None
+        else catalog.unadded(
+            cat, {s.set_code for s in inv.sets.values() if s.has_external}
+        )
+    )
+
     if set_code is not None and not rows:
         err_console.print(f"17Lands publishes no draft data for set {set_code}")
         raise typer.Exit(1)
@@ -465,6 +491,17 @@ def check(
             json.dumps(
                 {
                     "catalog_reachable": not cat.is_fallback,
+                    "unadded_expansions": [
+                        {
+                            "set_code": expansion,
+                            "last_updated": (
+                                cat.updated(expansion).isoformat()
+                                if cat.updated(expansion)
+                                else None
+                            ),
+                        }
+                        for expansion in unadded
+                    ],
                     "datasets": [
                         {
                             "set_code": r.target.expansion,
@@ -489,7 +526,7 @@ def check(
             )
         )
     else:
-        _render_check(rows, cat, held, detailed=set_code is not None)
+        _render_check(rows, cat, held, detailed=set_code is not None, unadded=unadded)
 
     if any(_is_actionable(r, held) for r in rows):
         raise typer.Exit(3)

--- a/spells/cli.py
+++ b/spells/cli.py
@@ -329,7 +329,9 @@ def _targets(
     if set_code is not None:
         expansions = [set_code]
     else:
-        expansions = [s.set_code for s in inv.sets.values() if s.has_external]
+        expansions = catalog.in_release_order(
+            cat, (s.set_code for s in inv.sets.values() if s.has_external)
+        )
 
     targets = []
     for expansion in expansions:

--- a/spells/cli.py
+++ b/spells/cli.py
@@ -9,9 +9,10 @@ from rich.console import Console
 from rich.padding import Padding
 from rich.table import Table
 
-from spells import cache, external, inventory
+from spells import cache, catalog, external, inventory
 from spells.cache import DataDir
-from spells.enums import EventType
+from spells.catalog import Freshness, Target
+from spells.enums import EventType, View
 from spells.inventory import Anomaly, AnomalyKind, Inventory
 
 ANOMALY_HELP = {
@@ -301,6 +302,197 @@ def clean(
 ) -> None:
     """Delete derived cache files. Always safe: they rebuild on demand."""
     raise typer.Exit(cache.clean(set_code))
+
+
+FRESHNESS_STYLE = {
+    Freshness.CURRENT: ("[green]current[/green]", "up to date"),
+    Freshness.STALE: ("[yellow]stale[/yellow]", "17Lands has newer data"),
+    Freshness.ABSENT: ("[cyan]absent[/cyan]", "published, not downloaded"),
+    Freshness.UNPUBLISHED: ("[dim]unpublished[/dim]", "17Lands does not publish it"),
+    Freshness.UNKNOWN: ("[dim]unknown[/dim]", "could not determine"),
+}
+
+CHECKED_VIEWS = (View.DRAFT, View.GAME)
+
+
+def _targets(
+    inv: Inventory, set_code: str | None, cat: catalog.Catalog
+) -> list[Target]:
+    """Every downloadable file worth asking about.
+
+    Sets already on disk are checked for staleness *and* for event types the
+    catalog publishes but we never added; a set with nothing on disk is only
+    reachable by naming it explicitly.
+    """
+    if set_code is not None:
+        expansions = [set_code]
+    else:
+        expansions = [s.set_code for s in inv.sets.values() if s.has_external]
+
+    targets = []
+    for expansion in expansions:
+        set_inv = inv.sets.get(expansion)
+        published = {
+            d.event_type for d in cat.for_expansion(expansion) if d.is_supported
+        }
+        held = set(set_inv.events) if set_inv else set()
+        for event_type in sorted(published | held):
+            files = set_inv.events.get(event_type) if set_inv else None
+            for view in CHECKED_VIEWS:
+                local = getattr(files, view, None) if files else None
+                targets.append(
+                    Target(expansion, event_type, view, local.mtime if local else None)
+                )
+    return targets
+
+
+def _held_events(inv: Inventory) -> set[tuple[str, EventType]]:
+    return {(s.set_code, event) for s in inv.sets.values() for event in s.events}
+
+
+def _is_actionable(row: catalog.CheckRow, held: set[tuple[str, EventType]]) -> bool:
+    """Whether a row represents something the user actually needs to do.
+
+    An event type they have never added is a suggestion, not a defect: nearly
+    every set publishes TradDraft, so counting those as work would make the
+    exit-3 contract fire permanently and be useless to cron.
+    """
+    if row.freshness == Freshness.STALE:
+        return True
+    key = (row.target.expansion, row.target.event_type)
+    return row.freshness == Freshness.ABSENT and key in held
+
+
+def _render_check(
+    rows: list[catalog.CheckRow],
+    cat: catalog.Catalog,
+    held: set[tuple[str, EventType]],
+    detailed: bool,
+) -> None:
+    if cat.is_fallback:
+        err_console.print(
+            "[yellow]Could not reach the 17Lands catalog; "
+            "reporting local state only.[/yellow]\n"
+        )
+
+    if not rows:
+        console.print("  [dim]Nothing to check. Try `spells add DSK`.[/dim]")
+        return
+
+    tracked = [r for r in rows if (r.target.expansion, r.target.event_type) in held]
+    untracked = [r for r in rows if r not in tracked]
+
+    if tracked:
+        table = Table(box=None, pad_edge=False, header_style="bold")
+        table.add_column("set")
+        table.add_column("event type")
+        table.add_column("file")
+        table.add_column("status")
+        table.add_column("updated", justify="right")
+
+        for row in tracked:
+            remote = row.remote
+            when = "[dim]—[/dim]"
+            if remote is not None and remote.last_modified is not None:
+                when = remote.last_modified.date().isoformat()
+            table.add_row(
+                row.target.expansion,
+                str(row.target.event_type),
+                str(row.target.view),
+                FRESHNESS_STYLE[row.freshness][0],
+                when,
+            )
+
+        console.print(Padding(table, (0, 0, 0, 2)))
+
+    if untracked:
+        available: dict[str, set[EventType]] = {}
+        for row in untracked:
+            if row.freshness == Freshness.ABSENT:
+                available.setdefault(row.target.expansion, set()).add(
+                    row.target.event_type
+                )
+
+        if available and detailed:
+            console.print("\n  [bold]also published[/bold] [dim](not added)[/dim]")
+            for expansion, events in sorted(available.items()):
+                names = ", ".join(sorted(str(e) for e in events))
+                console.print(f"    {expansion}: [cyan]{names}[/cyan]")
+        elif available:
+            events = sorted({str(e) for evs in available.values() for e in evs})
+            console.print(
+                f"\n  [dim]{len(available)} set(s) also publish "
+                f"{', '.join(events)} — `spells check <SET>` for detail[/dim]"
+            )
+
+    work = sorted({r.target.expansion for r in tracked if _is_actionable(r, held)})
+    if work:
+        console.print(
+            f"\n  [bold]{len(work)} set(s) incomplete or out of date:[/bold] "
+            f"{', '.join(work)}"
+        )
+        console.print(
+            "  [dim]`spells add <SET>` fills gaps, `refresh` re-downloads[/dim]"
+        )
+
+
+@app.command()
+def check(
+    set_code: Annotated[
+        str | None, typer.Argument(help="Limit to a single set.")
+    ] = None,
+    json_out: Annotated[
+        bool, typer.Option("--json", help="Machine-readable output.")
+    ] = False,
+) -> None:
+    """Compare local data against what 17Lands publishes.
+
+    Exits 3 when data you already track is out of date, so cron can chain on
+    it. Event types you have never added are reported but do not affect the
+    exit code.
+    """
+    inv = inventory.scan()
+    cat = catalog.fetch()
+    rows = catalog.resolve(_targets(inv, set_code, cat), cat)
+    held = _held_events(inv)
+
+    if set_code is not None and not rows:
+        err_console.print(f"17Lands publishes no draft data for set {set_code}")
+        raise typer.Exit(1)
+
+    if json_out:
+        print(
+            json.dumps(
+                {
+                    "catalog_reachable": not cat.is_fallback,
+                    "datasets": [
+                        {
+                            "set_code": r.target.expansion,
+                            "event_type": str(r.target.event_type),
+                            "view": str(r.target.view),
+                            "status": str(r.freshness),
+                            "tracked": (r.target.expansion, r.target.event_type)
+                            in held,
+                            "actionable": _is_actionable(r, held),
+                            "url": r.remote.url if r.remote else None,
+                            "remote_last_modified": (
+                                r.remote.last_modified.isoformat()
+                                if r.remote and r.remote.last_modified
+                                else None
+                            ),
+                            "remote_bytes": r.remote.size if r.remote else None,
+                        }
+                        for r in rows
+                    ],
+                },
+                indent=2,
+            )
+        )
+    else:
+        _render_check(rows, cat, held, detailed=set_code is not None)
+
+    if any(_is_actionable(r, held) for r in rows):
+        raise typer.Exit(3)
 
 
 @app.command()

--- a/spells/external.py
+++ b/spells/external.py
@@ -8,21 +8,16 @@ import os
 import shutil
 from enum import StrEnum
 
-import wget
 import polars as pl
 from polars.exceptions import ComputeError
 
 from spells import cards
 from spells import cache
+from spells import http
+from spells.catalog import DATASET_TEMPLATE, RESOURCE_TEMPLATE
 from spells.enums import View, ColName, EventType
 from spells.schema import schema
 from spells.draft_data import summon
-
-
-DATASET_TEMPLATE = "{dataset_type}_data_public.{set_code}.{event_type}.csv.gz"
-RESOURCE_TEMPLATE = (
-    "https://17lands-public.s3.amazonaws.com/analysis_data/{dataset_type}_data/"
-)
 
 class FileFormat(StrEnum):
     CSV = "csv"
@@ -177,8 +172,7 @@ def download_data_set(
     source_url = RESOURCE_TEMPLATE.format(dataset_type=dataset_type) + dataset_file
     dataset_path = os.path.join(cache.external_set_path(set_code), dataset_file)
     cache.spells_print(mode, f"Fetching {source_url}")
-    wget.download(source_url, out=dataset_path)
-    print()
+    http.download(source_url, dataset_path, description=dataset_file)
 
     cache.spells_print(
         mode, "Unzipping and transforming to parquet (this might take a few minutes)..."

--- a/spells/http.py
+++ b/spells/http.py
@@ -1,0 +1,119 @@
+"""One way to talk to the network.
+
+Every request spells makes goes through here so that the user agent, timeouts,
+and retry policy are set in one place rather than per call site.
+
+`download` writes through a `.part` file in the destination directory and
+renames it into place, so an interrupted download leaves an obviously partial
+file next to its target instead of a plausible-looking complete one.
+"""
+
+import os
+import threading
+
+import requests
+from requests.adapters import HTTPAdapter
+from rich.progress import (
+    BarColumn,
+    DownloadColumn,
+    Progress,
+    TextColumn,
+    TimeRemainingColumn,
+    TransferSpeedColumn,
+)
+from urllib3.util.retry import Retry
+
+USER_AGENT = "spells-mtg"
+TIMEOUT = 30
+
+# S3 and the Prismic CDN are both occasionally flaky, and the nightly DEq run is
+# unattended, so idempotent requests get a few automatic attempts.
+RETRY = Retry(
+    total=3,
+    backoff_factor=0.5,
+    status_forcelist=(429, 500, 502, 503, 504),
+    allowed_methods=("GET", "HEAD"),
+)
+
+_local = threading.local()
+
+
+def session() -> requests.Session:
+    """A Session per thread: `catalog.resolve` HEADs concurrently, and Session
+    is not documented as thread-safe."""
+    if (existing := getattr(_local, "session", None)) is not None:
+        return existing
+
+    new = requests.Session()
+    new.headers["User-Agent"] = USER_AGENT
+    adapter = HTTPAdapter(max_retries=RETRY)
+    new.mount("https://", adapter)
+    new.mount("http://", adapter)
+    _local.session = new
+    return new
+
+
+def get_json(url: str) -> dict:
+    response = session().get(url, timeout=TIMEOUT)
+    response.raise_for_status()
+    return response.json()
+
+
+def head(url: str) -> requests.Response | None:
+    """None if the object is missing or unreachable.
+
+    17Lands grants `public-read` per object rather than on the bucket, so an
+    unpublished dataset answers 403 rather than 404.
+    """
+    try:
+        response = session().head(url, timeout=TIMEOUT, allow_redirects=True)
+    except requests.RequestException:
+        return None
+    return response if response.ok else None
+
+
+def _progress() -> Progress:
+    return Progress(
+        TextColumn("  [progress.description]{task.description}"),
+        BarColumn(),
+        DownloadColumn(),
+        TransferSpeedColumn(),
+        TimeRemainingColumn(),
+    )
+
+
+def download(url: str, path: str, description: str = "", progress: bool = True) -> str:
+    """Stream `url` to `path`, returning the path actually written.
+
+    Unlike a bare write, the destination only ever appears once the transfer has
+    finished, so a failed run cannot leave a truncated file that later looks
+    complete to `spells status`.
+    """
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    part = f"{path}.part"
+
+    try:
+        with session().get(url, stream=True, timeout=TIMEOUT) as response:
+            response.raise_for_status()
+            total = int(response.headers.get("Content-Length") or 0)
+
+            with open(part, "wb") as f:
+                if not progress:
+                    for chunk in response.iter_content(chunk_size=1 << 20):
+                        f.write(chunk)
+                else:
+                    with _progress() as bar:
+                        task = bar.add_task(
+                            description or os.path.basename(path), total=total or None
+                        )
+                        for chunk in response.iter_content(chunk_size=1 << 20):
+                            f.write(chunk)
+                            bar.advance(task, len(chunk))
+
+        os.replace(part, path)
+    except BaseException:
+        if os.path.exists(part):
+            os.remove(part)
+        raise
+
+    return path

--- a/spells/inventory.py
+++ b/spells/inventory.py
@@ -52,6 +52,7 @@ class Anomaly:
 class FileInfo:
     path: Path
     size: int
+    mtime: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -150,7 +151,8 @@ def is_valid_snapshot(filename: str) -> bool:
 
 
 def _file_info(entry: os.DirEntry) -> FileInfo:
-    return FileInfo(path=Path(entry.path), size=entry.stat().st_size)
+    stat = entry.stat()
+    return FileInfo(path=Path(entry.path), size=stat.st_size, mtime=stat.st_mtime)
 
 
 def _scan_external_set(inv: SetInventory, set_dir: Path) -> None:

--- a/tests/card_ratings_view_test.py
+++ b/tests/card_ratings_view_test.py
@@ -6,7 +6,7 @@ All tests use fake set codes ("TST", "TS2") with no local parquet files.
 Ratings JSON is pre-seeded as snapshots at a past cache_usage date, so a cache
 miss raises instead of reaching the network (past snapshots cannot be
 refetched — 17lands resolves time periods against its own current date).
-Tests that exercise the fetch path itself monkeypatch wget.download.
+Tests that exercise the fetch path itself monkeypatch http.download.
 
 card_ratings_view() takes no filter_spec/card_context/set_context: the ratings
 API already returns one aggregated row per card, so there's nothing to
@@ -190,7 +190,7 @@ def test_omitted_cache_usage_defaults_to_today(fake_ratings_file, monkeypatch):
     # Today's snapshot isn't seeded, so the fetch path runs — the fake download
     # asserts the new /api/card_data query format and writes the payload where
     # the cache expects it.
-    def _fake_download(url, out):
+    def _fake_download(url, out, **kwargs):
         assert "https://www.17lands.com/api/card_data?" in url
         assert f"expansion={FAKE_SET}" in url
         assert "event_type=PremierDraft" in url
@@ -198,17 +198,17 @@ def test_omitted_cache_usage_defaults_to_today(fake_ratings_file, monkeypatch):
         assert "start_date" not in url
         Path(out).write_text(json.dumps(FAKE_CARD_RATINGS))
 
-    monkeypatch.setattr("spells.card_data_files.wget.download", _fake_download)
+    monkeypatch.setattr("spells.card_data_files.http.download", _fake_download)
 
     result = card_ratings_view(FAKE_SET, columns=["num_gih"], group_by=["name"])
     assert len(result) == len(FAKE_CARD_RATINGS)
 
 
 def test_explicit_cache_usage_none_same_as_omitted(fake_ratings_file, monkeypatch):
-    def _fake_download(url, out):
+    def _fake_download(url, out, **kwargs):
         Path(out).write_text(json.dumps(FAKE_CARD_RATINGS))
 
-    monkeypatch.setattr("spells.card_data_files.wget.download", _fake_download)
+    monkeypatch.setattr("spells.card_data_files.http.download", _fake_download)
 
     result = card_ratings_view(
         FAKE_SET, columns=["num_gih"], group_by=["name"], cache_usage=CacheUsage.NONE
@@ -288,11 +288,11 @@ def test_last_cached_accepts_plain_string(fake_ratings_file):
 def test_last_cached_falls_back_to_live_query_when_nothing_cached(monkeypatch, tmp_path):
     monkeypatch.setenv("SPELLS_DATA_HOME", str(tmp_path))
 
-    def _fake_download(url, out):
+    def _fake_download(url, out, **kwargs):
         assert "time_period=ALL_TIME" in url
         Path(out).write_text(json.dumps(FAKE_CARD_RATINGS))
 
-    monkeypatch.setattr("spells.card_data_files.wget.download", _fake_download)
+    monkeypatch.setattr("spells.card_data_files.http.download", _fake_download)
 
     result = card_ratings_view(
         FAKE_SET, columns=["num_gih"], group_by=["name"], cache_usage=CacheUsage.LAST
@@ -378,8 +378,8 @@ def unwarned():
 @pytest.fixture
 def fake_download(monkeypatch):
     monkeypatch.setattr(
-        "spells.card_data_files.wget.download",
-        lambda url, out: Path(out).write_text(json.dumps(FAKE_CARD_RATINGS)),
+        "spells.card_data_files.http.download",
+        lambda url, out, **kwargs: Path(out).write_text(json.dumps(FAKE_CARD_RATINGS)),
     )
 
 

--- a/tests/catalog_test.py
+++ b/tests/catalog_test.py
@@ -1,0 +1,225 @@
+import datetime
+import json
+from pathlib import Path
+
+import pytest
+
+from spells import catalog
+from spells.catalog import Catalog, Freshness, RemoteFile, Target
+from spells.enums import EventType, View
+
+FIXTURE = Path(__file__).parent / "data" / "prismic_public_data.json"
+
+
+@pytest.fixture
+def parsed() -> Catalog:
+    with open(FIXTURE) as f:
+        return catalog.parse(json.load(f))
+
+
+def test_parse_reads_every_dataset(parsed):
+    assert len(parsed.datasets) == 5
+
+
+def test_parse_maps_known_formats_to_event_types(parsed):
+    premier = parsed.get("MSH", EventType.PREMIER)
+    assert premier is not None
+    assert premier.format_name == "PremierDraft"
+    assert premier.is_supported
+
+
+def test_parse_extracts_s3_urls_from_hyperlink_spans(parsed):
+    premier = parsed.get("MSH", EventType.PREMIER)
+    assert premier.draft_url == (
+        "https://17lands-public.s3.amazonaws.com/analysis_data/draft_data/"
+        "draft_data_public.MSH.PremierDraft.csv.gz"
+    )
+    assert premier.url(View.GAME).endswith("game_data_public.MSH.PremierDraft.csv.gz")
+
+
+def test_parse_marks_unpublished_dataset_as_no_url(parsed):
+    """KHM renders a literal "-" for draft data; the object really is 403."""
+    khm = parsed.get("KHM", EventType.PREMIER)
+    assert khm.draft_url is None
+    assert khm.game_url is not None
+
+
+def test_parse_keeps_unsupported_formats_but_leaves_event_type_unset(parsed):
+    sealed = [d for d in parsed.datasets if d.format_name == "Sealed"]
+    assert len(sealed) == 1
+    assert sealed[0].event_type is None
+    assert not sealed[0].is_supported
+
+
+def test_get_never_matches_an_unsupported_format(parsed):
+    """`get` is keyed by EventType, so Sealed rows are unreachable through it."""
+    for dataset in parsed.datasets:
+        if not dataset.is_supported:
+            continue
+        assert parsed.get(dataset.expansion, dataset.event_type) is not None
+
+
+def test_parse_reads_last_updated_as_a_date(parsed):
+    assert parsed.get("BLB", EventType.TRADITIONAL).last_updated == datetime.date(
+        2024, 9, 5
+    )
+
+
+def test_expansions_are_deduplicated_in_order(parsed):
+    assert parsed.expansions == ("MSH", "KHM", "BLB")
+
+
+def test_for_expansion_groups_every_format(parsed):
+    assert len(parsed.for_expansion("MSH")) == 3
+
+
+def test_parse_skips_rows_missing_identity():
+    assert catalog.parse({"data": {"datasets": [{"expansion": [], "format": []}]}}) == (
+        Catalog(datasets=())
+    )
+
+
+def test_parse_tolerates_an_empty_document():
+    assert catalog.parse({}).datasets == ()
+
+
+def test_fetch_falls_back_when_17lands_is_unreachable(monkeypatch):
+    import urllib.error
+
+    monkeypatch.setattr(catalog, "_cached", None)
+
+    def unreachable(url):
+        raise urllib.error.URLError("no network")
+
+    monkeypatch.setattr(catalog, "_get_json", unreachable)
+
+    result = catalog.fetch()
+    assert result.is_fallback
+    assert result.datasets == ()
+
+
+def test_fallback_url_matches_the_published_layout(parsed):
+    assert (
+        catalog.fallback_url("MSH", View.DRAFT, EventType.PREMIER)
+        == parsed.get("MSH", EventType.PREMIER).draft_url
+    )
+
+
+UTC = datetime.timezone.utc
+
+
+def _remote(last_modified: datetime.datetime | None) -> RemoteFile:
+    return RemoteFile(url="https://example/x.csv.gz", last_modified=last_modified)
+
+
+def test_compare_reports_stale_when_remote_is_newer():
+    local = datetime.datetime(2026, 7, 1, tzinfo=UTC).timestamp()
+    remote = _remote(datetime.datetime(2026, 7, 27, tzinfo=UTC))
+    assert catalog.compare(local, remote) == Freshness.STALE
+
+
+def test_compare_reports_current_when_local_is_newer():
+    local = datetime.datetime(2026, 8, 5, tzinfo=UTC).timestamp()
+    remote = _remote(datetime.datetime(2026, 7, 27, tzinfo=UTC))
+    assert catalog.compare(local, remote) == Freshness.CURRENT
+
+
+def test_compare_reports_absent_when_published_but_not_downloaded():
+    remote = _remote(datetime.datetime(2026, 7, 27, tzinfo=UTC))
+    assert catalog.compare(None, remote) == Freshness.ABSENT
+
+
+def test_compare_reports_unpublished_when_neither_side_has_it():
+    assert catalog.compare(None, None) == Freshness.UNPUBLISHED
+
+
+def test_compare_will_not_call_a_local_file_unpublished():
+    """We have the data, so whatever the remote is doing, it is not "unpublished"."""
+    local = datetime.datetime(2026, 8, 5, tzinfo=UTC).timestamp()
+    assert catalog.compare(local, None) == Freshness.UNKNOWN
+
+
+def test_compare_is_unknown_without_a_last_modified_header():
+    local = datetime.datetime(2026, 8, 5, tzinfo=UTC).timestamp()
+    assert catalog.compare(local, _remote(None)) == Freshness.UNKNOWN
+
+
+STALE_MTIME = datetime.datetime(2026, 1, 1, tzinfo=UTC).timestamp()
+
+
+@pytest.fixture
+def no_head(monkeypatch):
+    """Every HEAD reports the same recent mtime, so freshness turns purely on
+    what the caller passes as the local mtime."""
+    calls = []
+
+    def fake_head(url):
+        calls.append(url)
+        return RemoteFile(
+            url=url, last_modified=datetime.datetime(2026, 7, 27, tzinfo=UTC)
+        )
+
+    monkeypatch.setattr(catalog, "head", fake_head)
+    return calls
+
+
+def test_resolve_heads_only_files_we_already_hold(parsed, no_head):
+    targets = [
+        Target("MSH", EventType.PREMIER, View.DRAFT, STALE_MTIME),
+        Target("MSH", EventType.PREMIER, View.GAME, None),
+    ]
+    rows = catalog.resolve(targets, parsed)
+
+    assert len(no_head) == 1
+    assert rows[0].freshness == Freshness.STALE
+    assert rows[1].freshness == Freshness.ABSENT
+
+
+def test_resolve_reports_absent_with_the_url_it_would_fetch(parsed, no_head):
+    (row,) = catalog.resolve(
+        [Target("MSH", EventType.PREMIER, View.GAME, None)], parsed
+    )
+    assert row.remote.url.endswith("game_data_public.MSH.PremierDraft.csv.gz")
+
+
+def test_resolve_calls_an_unpublished_dataset_unpublished(parsed, no_head):
+    (row,) = catalog.resolve(
+        [Target("KHM", EventType.PREMIER, View.DRAFT, None)], parsed
+    )
+    assert row.freshness == Freshness.UNPUBLISHED
+    assert not no_head
+
+
+def test_resolve_will_not_claim_unpublished_when_the_catalog_is_unreachable(no_head):
+    (row,) = catalog.resolve(
+        [Target("MSH", EventType.PREMIER, View.DRAFT, None)],
+        Catalog(datasets=(), is_fallback=True),
+    )
+    assert row.freshness == Freshness.UNKNOWN
+
+
+def test_resolve_preserves_target_order(parsed, no_head):
+    targets = [
+        Target("KHM", EventType.PREMIER, View.DRAFT, None),
+        Target("MSH", EventType.PREMIER, View.DRAFT, STALE_MTIME),
+        Target("BLB", EventType.TRADITIONAL, View.GAME, None),
+    ]
+    rows = catalog.resolve(targets, parsed)
+    assert [r.target for r in rows] == targets
+
+
+def test_needs_download_covers_stale_and_absent_only(parsed, no_head):
+    rows = catalog.resolve(
+        [
+            Target("MSH", EventType.PREMIER, View.DRAFT, STALE_MTIME),
+            Target("MSH", EventType.PREMIER, View.GAME, None),
+            Target("KHM", EventType.PREMIER, View.DRAFT, None),
+            Target("BLB", EventType.TRADITIONAL, View.DRAFT, _now()),
+        ],
+        parsed,
+    )
+    assert [r.needs_download for r in rows] == [True, True, False, False]
+
+
+def _now() -> float:
+    return datetime.datetime(2026, 8, 7, tzinfo=UTC).timestamp()

--- a/tests/catalog_test.py
+++ b/tests/catalog_test.py
@@ -1,4 +1,5 @@
 import datetime
+from dataclasses import replace
 import json
 from pathlib import Path
 
@@ -223,3 +224,53 @@ def test_needs_download_covers_stale_and_absent_only(parsed, no_head):
 
 def _now() -> float:
     return datetime.datetime(2026, 8, 7, tzinfo=UTC).timestamp()
+
+
+def test_is_addable_requires_published_draft_data(parsed):
+    """KHM's game data is published but its draft data 403s, so it cannot be added."""
+    assert parsed.is_addable("MSH")
+    assert not parsed.is_addable("KHM")
+
+
+def test_updated_takes_the_newest_across_event_types(parsed):
+    assert parsed.updated("MSH") == datetime.date(2026, 7, 26)
+
+
+def test_unadded_reports_missing_expansions_newest_first(parsed):
+    """Catalog order is MSH, KHM, BLB; holding KHM anchors at position 1."""
+    assert catalog.unadded(parsed, {"KHM"}) == ["BLB"]
+
+
+def test_unadded_ignores_expansions_predating_the_collection(parsed):
+    """BLB is last in this fixture, so holding it means nothing is newer."""
+    assert catalog.unadded(parsed, {"BLB"}) == []
+
+
+def test_unadded_never_offers_a_set_with_no_draft_data(parsed):
+    """KHM sits at position 1, so it is in range but still must not be offered."""
+    assert "KHM" not in catalog.unadded(parsed, {"MSH"})
+
+
+def test_unadded_with_nothing_held_offers_everything_addable(parsed):
+    assert catalog.unadded(parsed, set()) == ["BLB", "MSH"]
+
+
+def test_unadded_is_empty_when_everything_is_held(parsed):
+    assert catalog.unadded(parsed, {"MSH", "KHM", "BLB"}) == []
+
+
+def test_unadded_ignores_held_sets_absent_from_the_catalog(parsed):
+    """A local set 17Lands has retired must not break the anchor."""
+    assert catalog.unadded(parsed, {"BLB", "NOTASET"}) == []
+
+
+def test_unadded_orders_by_catalog_position_not_last_updated(parsed):
+    """17Lands bumps last_updated when regenerating old files; array order is
+    the stable release signal, so a regenerated old set must not look new."""
+    stale_first = Catalog(
+        datasets=tuple(
+            d if d.expansion != "KHM" else replace(d, last_updated=datetime.date(2099, 1, 1))
+            for d in parsed.datasets
+        )
+    )
+    assert catalog.unadded(stale_first, set()) == ["BLB", "MSH"]

--- a/tests/catalog_test.py
+++ b/tests/catalog_test.py
@@ -269,8 +269,35 @@ def test_unadded_orders_by_catalog_position_not_last_updated(parsed):
     the stable release signal, so a regenerated old set must not look new."""
     stale_first = Catalog(
         datasets=tuple(
-            d if d.expansion != "KHM" else replace(d, last_updated=datetime.date(2099, 1, 1))
+            d
+            if d.expansion != "KHM"
+            else replace(d, last_updated=datetime.date(2099, 1, 1))
             for d in parsed.datasets
         )
     )
     assert catalog.unadded(stale_first, set()) == ["BLB", "MSH"]
+
+
+def test_in_release_order_is_newest_first(parsed):
+    """Fixture array order is MSH, KHM, BLB, so BLB is the most recent."""
+    assert catalog.in_release_order(parsed, ["KHM", "MSH", "BLB"]) == [
+        "BLB",
+        "KHM",
+        "MSH",
+    ]
+
+
+def test_in_release_order_keeps_retired_expansions_at_the_end(parsed):
+    """A set on disk that 17Lands no longer lists must still be reported."""
+    assert catalog.in_release_order(parsed, ["ZZZ", "MSH", "AAA"]) == [
+        "MSH",
+        "AAA",
+        "ZZZ",
+    ]
+
+
+def test_in_release_order_survives_an_unreachable_catalog():
+    """With no catalog there is no release order, so fall back to alphabetical
+    rather than an arbitrary one."""
+    empty = Catalog(datasets=(), is_fallback=True)
+    assert catalog.in_release_order(empty, ["MSH", "BLB"]) == ["BLB", "MSH"]

--- a/tests/catalog_test.py
+++ b/tests/catalog_test.py
@@ -85,14 +85,14 @@ def test_parse_tolerates_an_empty_document():
 
 
 def test_fetch_falls_back_when_17lands_is_unreachable(monkeypatch):
-    import urllib.error
+    import requests
 
     monkeypatch.setattr(catalog, "_cached", None)
 
     def unreachable(url):
-        raise urllib.error.URLError("no network")
+        raise requests.ConnectionError("no network")
 
-    monkeypatch.setattr(catalog, "_get_json", unreachable)
+    monkeypatch.setattr(catalog.http, "get_json", unreachable)
 
     result = catalog.fetch()
     assert result.is_fallback

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -192,3 +192,152 @@ def test_status_omits_draft_logs_when_reporting_on_one_set(data_home):
 
     assert "cached draft logs" in runner.invoke(cli.app, ["status"]).stdout
     assert "cached draft logs" not in runner.invoke(cli.app, ["status", "TST"]).stdout
+
+
+# ---------------------------------------------------------------------------
+# check
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_catalog(monkeypatch):
+    """A catalog publishing TST in two event types, and nothing for KHM."""
+    import datetime
+
+    from spells.catalog import Catalog, Dataset, RemoteFile
+
+    def dataset(event_type, draft=True):
+        stub = f"https://example/{{}}_data_public.TST.{event_type}.csv.gz"
+        return Dataset(
+            expansion="TST",
+            format_name=str(event_type),
+            event_type=event_type,
+            last_updated=datetime.date(2026, 7, 26),
+            draft_url=stub.format("draft") if draft else None,
+            game_url=stub.format("game"),
+        )
+
+    cat = Catalog(datasets=(dataset(EventType.PREMIER), dataset(EventType.TRADITIONAL)))
+    monkeypatch.setattr(cli.catalog, "fetch", lambda *a, **k: cat)
+    monkeypatch.setattr(
+        cli.catalog,
+        "head",
+        lambda url: RemoteFile(
+            url=url,
+            last_modified=datetime.datetime(2026, 7, 27, tzinfo=datetime.timezone.utc),
+        ),
+    )
+    return cat
+
+
+REMOTE_MTIME = 1785110400  # 2026-07-27, what fake_catalog's HEAD reports
+
+
+def _set_mtime(data_home, when: int) -> None:
+    import os
+
+    for path in (data_home / "external" / "TST").glob("*.parquet"):
+        os.utime(path, (when, when))
+
+
+def test_check_flags_stale_local_data_and_exits_3(data_home, fake_catalog):
+    _set_mtime(data_home, REMOTE_MTIME - 86400)
+
+    result = runner.invoke(cli.app, ["check"])
+    assert result.exit_code == 3
+    assert "stale" in result.stdout
+
+
+def test_check_reports_an_event_type_published_but_never_added(data_home, fake_catalog):
+    """The whole point of the catalog: TradDraft exists and we do not have it."""
+    result = runner.invoke(cli.app, ["check", "--json"])
+    payload = json.loads(result.stdout)
+
+    trad = [d for d in payload["datasets"] if d["event_type"] == "TradDraft"]
+    assert trad and all(d["status"] == "absent" for d in trad)
+
+
+def test_check_json_carries_the_url_and_remote_timestamp(data_home, fake_catalog):
+    result = runner.invoke(cli.app, ["check", "--json"])
+    payload = json.loads(result.stdout)
+
+    assert payload["catalog_reachable"] is True
+    draft = next(
+        d
+        for d in payload["datasets"]
+        if d["event_type"] == "PremierDraft" and d["view"] == "draft"
+    )
+    assert draft["url"].endswith("draft_data_public.TST.PremierDraft.csv.gz")
+    assert draft["remote_last_modified"].startswith("2026-07-27")
+
+
+def test_check_reports_current_when_local_is_newer(data_home, fake_catalog):
+    _set_mtime(data_home, REMOTE_MTIME + 86400)
+
+    result = runner.invoke(cli.app, ["check", "TST", "--json"])
+    payload = json.loads(result.stdout)
+    held = [
+        d
+        for d in payload["datasets"]
+        if d["event_type"] == "PremierDraft" and d["view"] in ("draft", "game")
+    ]
+    assert all(d["status"] == "current" for d in held)
+
+
+def test_check_for_a_set_17lands_does_not_publish_exits_1(data_home, fake_catalog):
+    result = runner.invoke(cli.app, ["check", "NOPE"])
+    assert result.exit_code == 1
+
+
+def test_check_warns_but_does_not_claim_unpublished_when_offline(
+    monkeypatch, data_home
+):
+    from spells.catalog import Catalog
+
+    monkeypatch.setattr(
+        cli.catalog, "fetch", lambda *a, **k: Catalog(datasets=(), is_fallback=True)
+    )
+    result = runner.invoke(cli.app, ["check", "--json"])
+    payload = json.loads(result.stdout)
+
+    assert payload["catalog_reachable"] is False
+    assert all(d["status"] == "unknown" for d in payload["datasets"])
+
+
+def test_check_ignores_event_types_never_added_when_setting_exit_code(
+    data_home, fake_catalog
+):
+    """Nearly every set publishes TradDraft. Counting one the user never added
+    as "work to do" would make exit 3 fire permanently and be useless to cron."""
+    _set_mtime(data_home, REMOTE_MTIME + 86400)
+
+    result = runner.invoke(cli.app, ["check"])
+    assert result.exit_code == 0
+
+    payload = json.loads(runner.invoke(cli.app, ["check", "--json"]).stdout)
+    trad = [d for d in payload["datasets"] if d["event_type"] == "TradDraft"]
+    assert trad
+    assert all(d["status"] == "absent" for d in trad)
+    assert all(d["tracked"] is False for d in trad)
+    assert all(d["actionable"] is False for d in trad)
+
+
+def test_check_counts_a_missing_file_in_a_tracked_event_type_as_work(
+    data_home, fake_catalog
+):
+    """A half-downloaded event type is a real defect, unlike one never added."""
+    _set_mtime(data_home, REMOTE_MTIME + 86400)
+    (data_home / "external" / "TST" / "TST_PremierDraft_game.parquet").unlink()
+
+    result = runner.invoke(cli.app, ["check", "--json"])
+    assert result.exit_code == 3
+
+    payload = json.loads(result.stdout)
+    game = next(
+        d
+        for d in payload["datasets"]
+        if d["event_type"] == "PremierDraft" and d["view"] == "game"
+    )
+    assert game["status"] == "absent"
+    assert game["tracked"] is True
+    assert game["actionable"] is True

--- a/tests/data/prismic_public_data.json
+++ b/tests/data/prismic_public_data.json
@@ -1,0 +1,300 @@
+{
+  "data": {
+    "datasets": [
+      {
+        "expansion": [
+          {
+            "type": "paragraph",
+            "text": "MSH",
+            "spans": [],
+            "direction": "ltr"
+          }
+        ],
+        "format": [
+          {
+            "type": "paragraph",
+            "text": "PremierDraft",
+            "spans": [],
+            "direction": "ltr"
+          }
+        ],
+        "last_updated": [
+          {
+            "type": "paragraph",
+            "text": "2026-07-26",
+            "spans": [],
+            "direction": "ltr"
+          }
+        ],
+        "draft_data": [
+          {
+            "type": "paragraph",
+            "text": "link",
+            "spans": [
+              {
+                "start": 0,
+                "end": 4,
+                "type": "hyperlink",
+                "data": {
+                  "link_type": "Web",
+                  "url": "https://17lands-public.s3.amazonaws.com/analysis_data/draft_data/draft_data_public.MSH.PremierDraft.csv.gz",
+                  "target": "_blank"
+                }
+              }
+            ],
+            "direction": "ltr"
+          }
+        ],
+        "game_data": [
+          {
+            "type": "paragraph",
+            "text": "link",
+            "spans": [
+              {
+                "start": 0,
+                "end": 4,
+                "type": "hyperlink",
+                "data": {
+                  "link_type": "Web",
+                  "url": "https://17lands-public.s3.amazonaws.com/analysis_data/game_data/game_data_public.MSH.PremierDraft.csv.gz",
+                  "target": "_blank"
+                }
+              }
+            ],
+            "direction": "ltr"
+          }
+        ]
+      },
+      {
+        "expansion": [
+          {
+            "type": "paragraph",
+            "text": "MSH",
+            "spans": [],
+            "direction": "ltr"
+          }
+        ],
+        "format": [
+          {
+            "type": "paragraph",
+            "text": "PickTwoDraft",
+            "spans": [],
+            "direction": "ltr"
+          }
+        ],
+        "last_updated": [
+          {
+            "type": "paragraph",
+            "text": "2026-07-26",
+            "spans": [],
+            "direction": "ltr"
+          }
+        ],
+        "draft_data": [
+          {
+            "type": "paragraph",
+            "text": "link",
+            "spans": [
+              {
+                "start": 0,
+                "end": 4,
+                "type": "hyperlink",
+                "data": {
+                  "link_type": "Web",
+                  "url": "https://17lands-public.s3.amazonaws.com/analysis_data/draft_data/draft_data_public.MSH.PickTwoDraft.csv.gz",
+                  "target": "_blank"
+                }
+              }
+            ],
+            "direction": "ltr"
+          }
+        ],
+        "game_data": [
+          {
+            "type": "paragraph",
+            "text": "link",
+            "spans": [
+              {
+                "start": 0,
+                "end": 4,
+                "type": "hyperlink",
+                "data": {
+                  "link_type": "Web",
+                  "url": "https://17lands-public.s3.amazonaws.com/analysis_data/game_data/game_data_public.MSH.PickTwoDraft.csv.gz",
+                  "target": "_blank"
+                }
+              }
+            ],
+            "direction": "ltr"
+          }
+        ]
+      },
+      {
+        "expansion": [
+          {
+            "type": "paragraph",
+            "text": "MSH",
+            "spans": [],
+            "direction": "ltr"
+          }
+        ],
+        "format": [
+          {
+            "type": "paragraph",
+            "text": "Sealed",
+            "spans": [],
+            "direction": "ltr"
+          }
+        ],
+        "last_updated": [
+          {
+            "type": "paragraph",
+            "text": "2026-07-26",
+            "spans": [],
+            "direction": "ltr"
+          }
+        ],
+        "draft_data": [
+          {
+            "type": "paragraph",
+            "text": "-",
+            "spans": [],
+            "direction": "ltr"
+          }
+        ],
+        "game_data": [
+          {
+            "type": "paragraph",
+            "text": "link",
+            "spans": [
+              {
+                "start": 0,
+                "end": 4,
+                "type": "hyperlink",
+                "data": {
+                  "link_type": "Web",
+                  "url": "https://17lands-public.s3.amazonaws.com/analysis_data/game_data/game_data_public.MSH.Sealed.csv.gz",
+                  "target": "_blank"
+                }
+              }
+            ],
+            "direction": "ltr"
+          }
+        ]
+      },
+      {
+        "expansion": [
+          {
+            "type": "paragraph",
+            "text": "KHM",
+            "spans": []
+          }
+        ],
+        "format": [
+          {
+            "type": "paragraph",
+            "text": "PremierDraft",
+            "spans": []
+          }
+        ],
+        "last_updated": [
+          {
+            "type": "paragraph",
+            "text": "2021-04-04",
+            "spans": []
+          }
+        ],
+        "draft_data": [
+          {
+            "type": "paragraph",
+            "text": "-",
+            "spans": []
+          }
+        ],
+        "game_data": [
+          {
+            "type": "paragraph",
+            "text": "link",
+            "spans": [
+              {
+                "start": 0,
+                "end": 4,
+                "type": "hyperlink",
+                "data": {
+                  "link_type": "Web",
+                  "url": "https://17lands-public.s3.amazonaws.com/analysis_data/game_data/game_data_public.KHM.PremierDraft.csv.gz",
+                  "target": "_blank"
+                }
+              }
+            ],
+            "direction": "ltr"
+          }
+        ]
+      },
+      {
+        "expansion": [
+          {
+            "type": "paragraph",
+            "text": "BLB",
+            "spans": [],
+            "direction": "ltr"
+          }
+        ],
+        "format": [
+          {
+            "type": "paragraph",
+            "text": "TradDraft",
+            "spans": [],
+            "direction": "ltr"
+          }
+        ],
+        "last_updated": [
+          {
+            "type": "paragraph",
+            "text": "2024-09-05",
+            "spans": [],
+            "direction": "ltr"
+          }
+        ],
+        "draft_data": [
+          {
+            "type": "paragraph",
+            "text": "link",
+            "spans": [
+              {
+                "start": 0,
+                "end": 4,
+                "type": "hyperlink",
+                "data": {
+                  "link_type": "Web",
+                  "url": "https://17lands-public.s3.amazonaws.com/analysis_data/draft_data/draft_data_public.BLB.TradDraft.csv.gz",
+                  "target": "_blank"
+                }
+              }
+            ],
+            "direction": "ltr"
+          }
+        ],
+        "game_data": [
+          {
+            "type": "paragraph",
+            "text": "link",
+            "spans": [
+              {
+                "start": 0,
+                "end": 4,
+                "type": "hyperlink",
+                "data": {
+                  "link_type": "Web",
+                  "url": "https://17lands-public.s3.amazonaws.com/analysis_data/game_data/game_data_public.BLB.TradDraft.csv.gz",
+                  "target": "_self"
+                }
+              }
+            ],
+            "direction": "ltr"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/http_test.py
+++ b/tests/http_test.py
@@ -1,0 +1,226 @@
+"""Tests for the shared HTTP layer.
+
+The behaviors asserted here are the ones the previous `wget`-backed download
+got wrong: it staged into the *current working directory*, and it silently
+renamed to `name (1).ext` when the destination already existed, while callers
+went on using the path they had asked for.
+"""
+
+import os
+
+import pytest
+import requests
+
+from spells import http
+
+
+class FakeResponse:
+    def __init__(self, body=b"", headers=None, ok=True, status=200, json_data=None):
+        self.content = body
+        self.headers = headers or {}
+        self.ok = ok
+        self.status_code = status
+        self._json = json_data
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if not self.ok:
+            raise requests.HTTPError(f"{self.status_code}")
+
+    def iter_content(self, chunk_size=1):
+        for i in range(0, len(self.content), chunk_size):
+            yield self.content[i : i + chunk_size]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class FakeSession:
+    def __init__(self, response=None, error=None):
+        self.response = response
+        self.error = error
+        self.calls = []
+
+    def get(self, url, **kwargs):
+        self.calls.append(("get", url, kwargs))
+        if self.error:
+            raise self.error
+        return self.response
+
+    def head(self, url, **kwargs):
+        self.calls.append(("head", url, kwargs))
+        if self.error:
+            raise self.error
+        return self.response
+
+
+@pytest.fixture
+def fake_session(monkeypatch):
+    def install(response=None, error=None):
+        session = FakeSession(response, error)
+        monkeypatch.setattr(http, "session", lambda: session)
+        return session
+
+    return install
+
+
+def test_download_writes_the_exact_path_requested(tmp_path, fake_session):
+    fake_session(FakeResponse(b"payload", {"Content-Length": "7"}))
+    target = tmp_path / "sets" / "data.csv.gz"
+
+    written = http.download("https://example/x", str(target), progress=False)
+
+    assert written == str(target)
+    assert target.read_bytes() == b"payload"
+
+
+def test_download_overwrites_rather_than_renaming_alongside(tmp_path, fake_session):
+    """wget produced `data (1).csv.gz` here and returned it, while the caller
+    kept reading the stale file it had asked for."""
+    fake_session(FakeResponse(b"new", {"Content-Length": "3"}))
+    target = tmp_path / "data.csv.gz"
+    target.write_bytes(b"stale")
+
+    http.download("https://example/x", str(target), progress=False)
+
+    assert target.read_bytes() == b"new"
+    assert [p.name for p in tmp_path.iterdir()] == ["data.csv.gz"]
+
+
+def test_download_stages_inside_the_destination_directory(tmp_path, monkeypatch):
+    """wget staged its temp file in the cwd, littering whatever directory the
+    command happened to run from."""
+    seen = {}
+
+    class WatchingResponse(FakeResponse):
+        def iter_content(self, chunk_size=1):
+            seen["cwd"] = sorted(os.listdir("."))
+            seen["dest"] = sorted(os.listdir(tmp_path / "sets"))
+            return super().iter_content(chunk_size)
+
+    session = FakeSession(WatchingResponse(b"payload", {"Content-Length": "7"}))
+    monkeypatch.setattr(http, "session", lambda: session)
+
+    run_dir = tmp_path / "elsewhere"
+    run_dir.mkdir()
+    monkeypatch.chdir(run_dir)
+
+    http.download("https://example/x", str(tmp_path / "sets" / "d.gz"), progress=False)
+
+    assert seen["cwd"] == []
+    assert seen["dest"] == ["d.gz.part"]
+
+
+def test_download_leaves_no_file_behind_when_the_transfer_fails(tmp_path, fake_session):
+    class Exploding(FakeResponse):
+        def iter_content(self, chunk_size=1):
+            yield b"half"
+            raise requests.ConnectionError("dropped")
+
+    fake_session(Exploding(b"", {"Content-Length": "8"}))
+    target = tmp_path / "data.csv.gz"
+
+    with pytest.raises(requests.ConnectionError):
+        http.download("https://example/x", str(target), progress=False)
+
+    assert not target.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_download_does_not_clobber_the_target_on_failure(tmp_path, fake_session):
+    class Exploding(FakeResponse):
+        def iter_content(self, chunk_size=1):
+            raise requests.ConnectionError("dropped")
+            yield
+
+    fake_session(Exploding(b"", {"Content-Length": "8"}))
+    target = tmp_path / "data.csv.gz"
+    target.write_bytes(b"good data")
+
+    with pytest.raises(requests.ConnectionError):
+        http.download("https://example/x", str(target), progress=False)
+
+    assert target.read_bytes() == b"good data"
+
+
+def test_download_raises_on_an_error_status(tmp_path, fake_session):
+    fake_session(FakeResponse(b"", ok=False, status=403))
+    target = tmp_path / "data.csv.gz"
+
+    with pytest.raises(requests.HTTPError):
+        http.download("https://example/x", str(target), progress=False)
+
+    assert not target.exists()
+
+
+def test_head_returns_none_for_an_unpublished_object(fake_session):
+    fake_session(FakeResponse(ok=False, status=403))
+    assert http.head("https://example/missing") is None
+
+
+def test_head_returns_none_when_unreachable(fake_session):
+    fake_session(error=requests.ConnectionError("no network"))
+    assert http.head("https://example/x") is None
+
+
+def test_head_returns_the_response_when_published(fake_session):
+    fake_session(FakeResponse(headers={"Content-Length": "10"}))
+    response = http.head("https://example/x")
+    assert response is not None
+    assert response.headers["Content-Length"] == "10"
+
+
+def test_get_json_returns_the_decoded_body(fake_session):
+    fake_session(FakeResponse(json_data={"refs": [{"ref": "abc"}]}))
+    assert http.get_json("https://example/api")["refs"][0]["ref"] == "abc"
+
+
+def test_get_json_raises_on_an_error_status(fake_session):
+    fake_session(FakeResponse(ok=False, status=500))
+    with pytest.raises(requests.HTTPError):
+        http.get_json("https://example/api")
+
+
+def test_requests_carry_a_timeout(tmp_path, fake_session):
+    session = fake_session(FakeResponse(json_data={}))
+    http.get_json("https://example/api")
+    assert session.calls[0][2]["timeout"] == http.TIMEOUT
+
+
+def test_sessions_are_per_thread():
+    """catalog.resolve HEADs concurrently, and Session is not thread-safe.
+
+    A barrier forces both threads to be live at once; a plain thread pool is
+    free to run two quick tasks on the same worker and would prove nothing.
+    """
+    import threading
+
+    barrier = threading.Barrier(2)
+    ids = []
+    lock = threading.Lock()
+
+    def record():
+        barrier.wait(timeout=5)
+        with lock:
+            ids.append(id(http.session()))
+
+    threads = [threading.Thread(target=record) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert len(set(ids)) == 2
+
+
+def test_session_is_reused_within_one_thread():
+    assert http.session() is http.session()
+
+
+def test_session_sets_the_user_agent():
+    assert http.session().headers["User-Agent"] == http.USER_AGENT


### PR DESCRIPTION
Phase 4 of `.claude/plans/spells-cli-file-management.md`, pulled ahead of Phase 2 (doctor/snapshots) because the `spells manage` end goal needs "available sets" to be a real concept before anything else is built on top of it.

## What this adds

`spells catalog` module + `spells check [SET] [--json]`.

```
$ spells check MSH
  set  event type    file   status      updated
  MSH  PremierDraft  draft  current  2026-07-27
  MSH  PremierDraft  game   current  2026-07-27

  also published (not added)
    MSH: PickTwoDraft, TradDraft
```

## Why the Prismic catalog

The Public Datasets page is a Prismic CMS document, not a 17Lands API. It's public, unauthenticated, and its hyperlink spans carry the canonical S3 URLs — so per plan decision 0, the addresses come from the public website at runtime rather than from our own assumptions.

It also **enumerates**, which nothing else can: S3 objects are `public-read` but the bucket is not listable. That's what makes "MSH TradDraft is published and you don't have it" expressible at all.

Verified live: 129 datasets across 35 expansions. `KHM` draft data is listed as `-`, and the corresponding S3 object really does return **403** — so the catalog lets `add` explain itself instead of failing on an opaque error.

## Corrections to the plan's assumptions

- It's **one document with a `datasets` array**, not 128 separate documents.
- Fields are `draft_data`/`game_data`/`replay_data`, not `draft`/`game`.
- Catalog carries formats spells doesn't model — `Sealed` (30), `TradSealed` (29), `QuickDraft` (1), `PickTwoTradDraft` (1). These parse into `Dataset` with `event_type=None` and are surfaced as unsupported rather than dropped.
- `replay_data` is real published data spells has no concept of; deliberately not modeled.
- The plan's note that MSH is stale is itself now stale — local MSH is dated 2026-08-05, ahead of the remote 2026-07-27.

## Freshness is two-tier

`last_updated` in the catalog is hand-maintained and lags (MSH: catalog says 07-26, S3 says 07-27), so it's display-only. The actual decision comes from a HEAD on the catalog-supplied URL vs. the local parquet mtime.

## Exit-3 contract: tracked vs. published

Worth a look, since it's a design change rather than a straight port. A first cut counted every published-but-absent dataset as work to do, which flagged **24 of ~30 sets** — because nearly every set publishes TradDraft and only Premier was ever added. That would make `spells check X; [ $? -eq 3 ] && ...` fire permanently.

So exit 3 now means *data you already track is incomplete or out of date*. An event type never added is reported but doesn't affect the exit code. After the change the same sweep flags exactly one set — **HBG**, which genuinely has a draft parquet and no game file (an anomaly already recorded in the plan).

`--json` exposes both `tracked` and `actionable` per row so scripts can pick their own policy.

## Performance

Only files already on disk get HEADed (the catalog alone establishes that a missing one is published), and those run concurrently. Full sweep of the 9.6G data home: ~2.2s.

## Testing

25 new catalog tests + 8 new CLI tests; 181 total, all passing. `catalog.py` splits `parse()` from fetching so parsing is tested against a saved Prismic fixture (`tests/data/prismic_public_data.json`) covering a supported format, an unpublished `-` row, and an unsupported `Sealed` row. No test touches the network.

## Note

`ruff check` reports one pre-existing unused import at `spells/cards.py:3` — present on `main`, left alone here to keep this diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)