### PR TITLE
Replace wget with requests behind one HTTP module

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:fed85b456326cd21410e4a1ae381fe9600de77a3cea255b9b1bc888387a08c1a"
+content_hash = "sha256:fe6310f6457838015ada16a013c1e07b44f00b379a6e49afbf96a7b08b795334"
 
 [[metadata.targets]]
 requires_python = ">=3.13"
@@ -202,7 +202,7 @@ name = "certifi"
 version = "2024.12.14"
 requires_python = ">=3.6"
 summary = "Python package for providing Mozilla's CA Bundle."
-groups = ["dev"]
+groups = ["default", "dev"]
 files = [
     {file = "certifi-2024.12.14-py3-none-any.whl", hash = "sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56"},
     {file = "certifi-2024.12.14.tar.gz", hash = "sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db"},
@@ -260,7 +260,7 @@ name = "charset-normalizer"
 version = "3.4.1"
 requires_python = ">=3.7"
 summary = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
-groups = ["dev"]
+groups = ["default", "dev"]
 files = [
     {file = "charset_normalizer-3.4.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:8bfa33f4f2672964266e940dd22a195989ba31669bd84629f05fab3ef4e2d125"},
     {file = "charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28bf57629c75e810b6ae989f03c0828d64d6b26a5e205535585f96093e405ed1"},
@@ -561,7 +561,7 @@ name = "idna"
 version = "3.10"
 requires_python = ">=3.6"
 summary = "Internationalized Domain Names in Applications (IDNA)"
-groups = ["dev"]
+groups = ["default", "dev"]
 files = [
     {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
     {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
@@ -1805,7 +1805,7 @@ name = "requests"
 version = "2.32.3"
 requires_python = ">=3.8"
 summary = "Python HTTP for Humans."
-groups = ["dev"]
+groups = ["default", "dev"]
 dependencies = [
     "certifi>=2017.4.17",
     "charset-normalizer<4,>=2",
@@ -2132,7 +2132,7 @@ name = "urllib3"
 version = "2.3.0"
 requires_python = ">=3.9"
 summary = "HTTP library with thread-safe connection pooling, file post, and more."
-groups = ["dev"]
+groups = ["default", "dev"]
 files = [
     {file = "urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df"},
     {file = "urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d"},
@@ -2181,15 +2181,6 @@ groups = ["dev"]
 files = [
     {file = "websocket_client-1.8.0-py3-none-any.whl", hash = "sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526"},
     {file = "websocket_client-1.8.0.tar.gz", hash = "sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da"},
-]
-
-[[package]]
-name = "wget"
-version = "3.2"
-summary = "pure python download utility"
-groups = ["default"]
-files = [
-    {file = "wget-3.2.zip", hash = "sha256:35e630eca2aa50ce998b9b1a127bb26b30dfee573702782aa982f875e3f16061"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 dependencies = [
     "polars==1.22.0",
-    "wget>=3.2",
+    "requests>=2.32",
     "typer>=0.27.0",
 ]
 requires-python = ">=3.13"

--- a/spells/card_data_files.py
+++ b/spells/card_data_files.py
@@ -12,12 +12,12 @@ import json
 import logging
 import os
 from pathlib import Path
-import wget
 from time import sleep
 
 import polars as pl
 
 from spells import cache
+from spells import http
 from spells.enums import ColName, EventType, TimePeriod
 
 RATINGS_TEMPLATE = (
@@ -107,7 +107,7 @@ def download_data_file(url: str, target_dir: str, filename: str) -> str:
     file_path = os.path.join(target_dir, filename)
 
     if not os.path.isfile(file_path):
-        wget.download(url, out=file_path)
+        http.download(url, file_path, progress=False)
 
     return file_path
 

--- a/spells/cards.py
+++ b/spells/cards.py
@@ -1,12 +1,11 @@
 import json
 import os
-import re
-import urllib.request
 from enum import StrEnum
 
 import polars as pl
 
 from spells import cache
+from spells import http
 from spells.enums import ColName, View, EventType
 
 
@@ -34,15 +33,7 @@ MTG_JSON_TEMPLATE = "https://mtgjson.com/api/v5/{set_code}.json"
 
 
 def _fetch_mtg_json(set_code: str) -> dict:
-    request = urllib.request.Request(
-        MTG_JSON_TEMPLATE.format(set_code=set_code),
-        headers={"User-Agent": "spells-mtg/0.1.0"},
-    )
-
-    with urllib.request.urlopen(request) as f:
-        draft_set_json = json.loads(f.read().decode("utf-8"))
-
-    return draft_set_json
+    return http.get_json(MTG_JSON_TEMPLATE.format(set_code=set_code))
 
 
 def _extract_value(set_code: str, name: str, card_dict: dict, field: CardAttr):

--- a/spells/catalog.py
+++ b/spells/catalog.py
@@ -24,11 +24,11 @@ from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from email.utils import parsedate_to_datetime
 from enum import StrEnum
-import json
-import urllib.error
 import urllib.parse
-import urllib.request
 
+import requests
+
+from spells import http
 from spells.enums import EventType, View
 
 PRISMIC_API = "https://17lands.cdn.prismic.io/api/v2"
@@ -40,9 +40,6 @@ DATASET_TEMPLATE = "{dataset_type}_data_public.{set_code}.{event_type}.csv.gz"
 RESOURCE_TEMPLATE = (
     "https://17lands-public.s3.amazonaws.com/analysis_data/{dataset_type}_data/"
 )
-
-USER_AGENT = "spells-mtg"
-TIMEOUT = 30
 
 
 class Freshness(StrEnum):
@@ -161,16 +158,10 @@ def parse(document: dict) -> Catalog:
     return Catalog(datasets=tuple(datasets))
 
 
-def _get_json(url: str) -> dict:
-    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
-    with urllib.request.urlopen(request, timeout=TIMEOUT) as response:
-        return json.loads(response.read().decode("utf-8"))
-
-
 def _fetch_document() -> dict:
-    ref = _get_json(PRISMIC_API)["refs"][0]["ref"]
+    ref = http.get_json(PRISMIC_API)["refs"][0]["ref"]
     query = urllib.parse.urlencode({"ref": ref, "q": PRISMIC_QUERY, "pageSize": 100})
-    results = _get_json(f"{PRISMIC_API}/documents/search?{query}")["results"]
+    results = http.get_json(f"{PRISMIC_API}/documents/search?{query}")["results"]
     if not results:
         raise ValueError("no public-data document in the 17Lands catalog")
     return results[0]
@@ -191,13 +182,7 @@ def fetch(refresh: bool = False) -> Catalog:
 
     try:
         _cached = parse(_fetch_document())
-    except (
-        urllib.error.URLError,
-        TimeoutError,
-        KeyError,
-        ValueError,
-        json.JSONDecodeError,
-    ):
+    except (requests.RequestException, KeyError, ValueError):
         _cached = Catalog(datasets=(), is_fallback=True)
     return _cached
 
@@ -209,19 +194,11 @@ def fallback_url(expansion: str, view: View, event_type: EventType) -> str:
 
 
 def head(url: str) -> RemoteFile | None:
-    """Remote metadata, or None if the object is missing or unreachable.
-
-    Unpublished datasets are `public-read` only for objects that exist, so a
-    stale or guessed URL comes back 403 rather than 404.
-    """
-    request = urllib.request.Request(
-        url, method="HEAD", headers={"User-Agent": USER_AGENT}
-    )
-    try:
-        with urllib.request.urlopen(request, timeout=TIMEOUT) as response:
-            headers = response.headers
-    except (urllib.error.URLError, TimeoutError):
+    """Remote metadata, or None if the object is missing or unreachable."""
+    response = http.head(url)
+    if response is None:
         return None
+    headers = response.headers
 
     last_modified = None
     if raw := headers.get("Last-Modified"):

--- a/spells/external.py
+++ b/spells/external.py
@@ -8,21 +8,16 @@ import os
 import shutil
 from enum import StrEnum
 
-import wget
 import polars as pl
 from polars.exceptions import ComputeError
 
 from spells import cards
 from spells import cache
+from spells import http
+from spells.catalog import DATASET_TEMPLATE, RESOURCE_TEMPLATE
 from spells.enums import View, ColName, EventType
 from spells.schema import schema
 from spells.draft_data import summon
-
-
-DATASET_TEMPLATE = "{dataset_type}_data_public.{set_code}.{event_type}.csv.gz"
-RESOURCE_TEMPLATE = (
-    "https://17lands-public.s3.amazonaws.com/analysis_data/{dataset_type}_data/"
-)
 
 class FileFormat(StrEnum):
     CSV = "csv"
@@ -177,8 +172,7 @@ def download_data_set(
     source_url = RESOURCE_TEMPLATE.format(dataset_type=dataset_type) + dataset_file
     dataset_path = os.path.join(cache.external_set_path(set_code), dataset_file)
     cache.spells_print(mode, f"Fetching {source_url}")
-    wget.download(source_url, out=dataset_path)
-    print()
+    http.download(source_url, dataset_path, description=dataset_file)
 
     cache.spells_print(
         mode, "Unzipping and transforming to parquet (this might take a few minutes)..."

--- a/spells/http.py
+++ b/spells/http.py
@@ -1,0 +1,119 @@
+"""One way to talk to the network.
+
+Every request spells makes goes through here so that the user agent, timeouts,
+and retry policy are set in one place rather than per call site.
+
+`download` writes through a `.part` file in the destination directory and
+renames it into place, so an interrupted download leaves an obviously partial
+file next to its target instead of a plausible-looking complete one.
+"""
+
+import os
+import threading
+
+import requests
+from requests.adapters import HTTPAdapter
+from rich.progress import (
+    BarColumn,
+    DownloadColumn,
+    Progress,
+    TextColumn,
+    TimeRemainingColumn,
+    TransferSpeedColumn,
+)
+from urllib3.util.retry import Retry
+
+USER_AGENT = "spells-mtg"
+TIMEOUT = 30
+
+# S3 and the Prismic CDN are both occasionally flaky, and the nightly DEq run is
+# unattended, so idempotent requests get a few automatic attempts.
+RETRY = Retry(
+    total=3,
+    backoff_factor=0.5,
+    status_forcelist=(429, 500, 502, 503, 504),
+    allowed_methods=("GET", "HEAD"),
+)
+
+_local = threading.local()
+
+
+def session() -> requests.Session:
+    """A Session per thread: `catalog.resolve` HEADs concurrently, and Session
+    is not documented as thread-safe."""
+    if (existing := getattr(_local, "session", None)) is not None:
+        return existing
+
+    new = requests.Session()
+    new.headers["User-Agent"] = USER_AGENT
+    adapter = HTTPAdapter(max_retries=RETRY)
+    new.mount("https://", adapter)
+    new.mount("http://", adapter)
+    _local.session = new
+    return new
+
+
+def get_json(url: str) -> dict:
+    response = session().get(url, timeout=TIMEOUT)
+    response.raise_for_status()
+    return response.json()
+
+
+def head(url: str) -> requests.Response | None:
+    """None if the object is missing or unreachable.
+
+    17Lands grants `public-read` per object rather than on the bucket, so an
+    unpublished dataset answers 403 rather than 404.
+    """
+    try:
+        response = session().head(url, timeout=TIMEOUT, allow_redirects=True)
+    except requests.RequestException:
+        return None
+    return response if response.ok else None
+
+
+def _progress() -> Progress:
+    return Progress(
+        TextColumn("  [progress.description]{task.description}"),
+        BarColumn(),
+        DownloadColumn(),
+        TransferSpeedColumn(),
+        TimeRemainingColumn(),
+    )
+
+
+def download(url: str, path: str, description: str = "", progress: bool = True) -> str:
+    """Stream `url` to `path`, returning the path actually written.
+
+    Unlike a bare write, the destination only ever appears once the transfer has
+    finished, so a failed run cannot leave a truncated file that later looks
+    complete to `spells status`.
+    """
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    part = f"{path}.part"
+
+    try:
+        with session().get(url, stream=True, timeout=TIMEOUT) as response:
+            response.raise_for_status()
+            total = int(response.headers.get("Content-Length") or 0)
+
+            with open(part, "wb") as f:
+                if not progress:
+                    for chunk in response.iter_content(chunk_size=1 << 20):
+                        f.write(chunk)
+                else:
+                    with _progress() as bar:
+                        task = bar.add_task(
+                            description or os.path.basename(path), total=total or None
+                        )
+                        for chunk in response.iter_content(chunk_size=1 << 20):
+                            f.write(chunk)
+                            bar.advance(task, len(chunk))
+
+        os.replace(part, path)
+    except BaseException:
+        if os.path.exists(part):
+            os.remove(part)
+        raise
+
+    return path

--- a/tests/card_ratings_view_test.py
+++ b/tests/card_ratings_view_test.py
@@ -6,7 +6,7 @@ All tests use fake set codes ("TST", "TS2") with no local parquet files.
 Ratings JSON is pre-seeded as snapshots at a past cache_usage date, so a cache
 miss raises instead of reaching the network (past snapshots cannot be
 refetched — 17lands resolves time periods against its own current date).
-Tests that exercise the fetch path itself monkeypatch wget.download.
+Tests that exercise the fetch path itself monkeypatch http.download.
 
 card_ratings_view() takes no filter_spec/card_context/set_context: the ratings
 API already returns one aggregated row per card, so there's nothing to
@@ -190,7 +190,7 @@ def test_omitted_cache_usage_defaults_to_today(fake_ratings_file, monkeypatch):
     # Today's snapshot isn't seeded, so the fetch path runs — the fake download
     # asserts the new /api/card_data query format and writes the payload where
     # the cache expects it.
-    def _fake_download(url, out):
+    def _fake_download(url, out, **kwargs):
         assert "https://www.17lands.com/api/card_data?" in url
         assert f"expansion={FAKE_SET}" in url
         assert "event_type=PremierDraft" in url
@@ -198,17 +198,17 @@ def test_omitted_cache_usage_defaults_to_today(fake_ratings_file, monkeypatch):
         assert "start_date" not in url
         Path(out).write_text(json.dumps(FAKE_CARD_RATINGS))
 
-    monkeypatch.setattr("spells.card_data_files.wget.download", _fake_download)
+    monkeypatch.setattr("spells.card_data_files.http.download", _fake_download)
 
     result = card_ratings_view(FAKE_SET, columns=["num_gih"], group_by=["name"])
     assert len(result) == len(FAKE_CARD_RATINGS)
 
 
 def test_explicit_cache_usage_none_same_as_omitted(fake_ratings_file, monkeypatch):
-    def _fake_download(url, out):
+    def _fake_download(url, out, **kwargs):
         Path(out).write_text(json.dumps(FAKE_CARD_RATINGS))
 
-    monkeypatch.setattr("spells.card_data_files.wget.download", _fake_download)
+    monkeypatch.setattr("spells.card_data_files.http.download", _fake_download)
 
     result = card_ratings_view(
         FAKE_SET, columns=["num_gih"], group_by=["name"], cache_usage=CacheUsage.NONE
@@ -288,11 +288,11 @@ def test_last_cached_accepts_plain_string(fake_ratings_file):
 def test_last_cached_falls_back_to_live_query_when_nothing_cached(monkeypatch, tmp_path):
     monkeypatch.setenv("SPELLS_DATA_HOME", str(tmp_path))
 
-    def _fake_download(url, out):
+    def _fake_download(url, out, **kwargs):
         assert "time_period=ALL_TIME" in url
         Path(out).write_text(json.dumps(FAKE_CARD_RATINGS))
 
-    monkeypatch.setattr("spells.card_data_files.wget.download", _fake_download)
+    monkeypatch.setattr("spells.card_data_files.http.download", _fake_download)
 
     result = card_ratings_view(
         FAKE_SET, columns=["num_gih"], group_by=["name"], cache_usage=CacheUsage.LAST
@@ -378,8 +378,8 @@ def unwarned():
 @pytest.fixture
 def fake_download(monkeypatch):
     monkeypatch.setattr(
-        "spells.card_data_files.wget.download",
-        lambda url, out: Path(out).write_text(json.dumps(FAKE_CARD_RATINGS)),
+        "spells.card_data_files.http.download",
+        lambda url, out, **kwargs: Path(out).write_text(json.dumps(FAKE_CARD_RATINGS)),
     )
 
 

--- a/tests/catalog_test.py
+++ b/tests/catalog_test.py
@@ -85,14 +85,14 @@ def test_parse_tolerates_an_empty_document():
 
 
 def test_fetch_falls_back_when_17lands_is_unreachable(monkeypatch):
-    import urllib.error
+    import requests
 
     monkeypatch.setattr(catalog, "_cached", None)
 
     def unreachable(url):
-        raise urllib.error.URLError("no network")
+        raise requests.ConnectionError("no network")
 
-    monkeypatch.setattr(catalog, "_get_json", unreachable)
+    monkeypatch.setattr(catalog.http, "get_json", unreachable)
 
     result = catalog.fetch()
     assert result.is_fallback

--- a/tests/http_test.py
+++ b/tests/http_test.py
@@ -1,0 +1,226 @@
+"""Tests for the shared HTTP layer.
+
+The behaviors asserted here are the ones the previous `wget`-backed download
+got wrong: it staged into the *current working directory*, and it silently
+renamed to `name (1).ext` when the destination already existed, while callers
+went on using the path they had asked for.
+"""
+
+import os
+
+import pytest
+import requests
+
+from spells import http
+
+
+class FakeResponse:
+    def __init__(self, body=b"", headers=None, ok=True, status=200, json_data=None):
+        self.content = body
+        self.headers = headers or {}
+        self.ok = ok
+        self.status_code = status
+        self._json = json_data
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if not self.ok:
+            raise requests.HTTPError(f"{self.status_code}")
+
+    def iter_content(self, chunk_size=1):
+        for i in range(0, len(self.content), chunk_size):
+            yield self.content[i : i + chunk_size]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class FakeSession:
+    def __init__(self, response=None, error=None):
+        self.response = response
+        self.error = error
+        self.calls = []
+
+    def get(self, url, **kwargs):
+        self.calls.append(("get", url, kwargs))
+        if self.error:
+            raise self.error
+        return self.response
+
+    def head(self, url, **kwargs):
+        self.calls.append(("head", url, kwargs))
+        if self.error:
+            raise self.error
+        return self.response
+
+
+@pytest.fixture
+def fake_session(monkeypatch):
+    def install(response=None, error=None):
+        session = FakeSession(response, error)
+        monkeypatch.setattr(http, "session", lambda: session)
+        return session
+
+    return install
+
+
+def test_download_writes_the_exact_path_requested(tmp_path, fake_session):
+    fake_session(FakeResponse(b"payload", {"Content-Length": "7"}))
+    target = tmp_path / "sets" / "data.csv.gz"
+
+    written = http.download("https://example/x", str(target), progress=False)
+
+    assert written == str(target)
+    assert target.read_bytes() == b"payload"
+
+
+def test_download_overwrites_rather_than_renaming_alongside(tmp_path, fake_session):
+    """wget produced `data (1).csv.gz` here and returned it, while the caller
+    kept reading the stale file it had asked for."""
+    fake_session(FakeResponse(b"new", {"Content-Length": "3"}))
+    target = tmp_path / "data.csv.gz"
+    target.write_bytes(b"stale")
+
+    http.download("https://example/x", str(target), progress=False)
+
+    assert target.read_bytes() == b"new"
+    assert [p.name for p in tmp_path.iterdir()] == ["data.csv.gz"]
+
+
+def test_download_stages_inside_the_destination_directory(tmp_path, monkeypatch):
+    """wget staged its temp file in the cwd, littering whatever directory the
+    command happened to run from."""
+    seen = {}
+
+    class WatchingResponse(FakeResponse):
+        def iter_content(self, chunk_size=1):
+            seen["cwd"] = sorted(os.listdir("."))
+            seen["dest"] = sorted(os.listdir(tmp_path / "sets"))
+            return super().iter_content(chunk_size)
+
+    session = FakeSession(WatchingResponse(b"payload", {"Content-Length": "7"}))
+    monkeypatch.setattr(http, "session", lambda: session)
+
+    run_dir = tmp_path / "elsewhere"
+    run_dir.mkdir()
+    monkeypatch.chdir(run_dir)
+
+    http.download("https://example/x", str(tmp_path / "sets" / "d.gz"), progress=False)
+
+    assert seen["cwd"] == []
+    assert seen["dest"] == ["d.gz.part"]
+
+
+def test_download_leaves_no_file_behind_when_the_transfer_fails(tmp_path, fake_session):
+    class Exploding(FakeResponse):
+        def iter_content(self, chunk_size=1):
+            yield b"half"
+            raise requests.ConnectionError("dropped")
+
+    fake_session(Exploding(b"", {"Content-Length": "8"}))
+    target = tmp_path / "data.csv.gz"
+
+    with pytest.raises(requests.ConnectionError):
+        http.download("https://example/x", str(target), progress=False)
+
+    assert not target.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_download_does_not_clobber_the_target_on_failure(tmp_path, fake_session):
+    class Exploding(FakeResponse):
+        def iter_content(self, chunk_size=1):
+            raise requests.ConnectionError("dropped")
+            yield
+
+    fake_session(Exploding(b"", {"Content-Length": "8"}))
+    target = tmp_path / "data.csv.gz"
+    target.write_bytes(b"good data")
+
+    with pytest.raises(requests.ConnectionError):
+        http.download("https://example/x", str(target), progress=False)
+
+    assert target.read_bytes() == b"good data"
+
+
+def test_download_raises_on_an_error_status(tmp_path, fake_session):
+    fake_session(FakeResponse(b"", ok=False, status=403))
+    target = tmp_path / "data.csv.gz"
+
+    with pytest.raises(requests.HTTPError):
+        http.download("https://example/x", str(target), progress=False)
+
+    assert not target.exists()
+
+
+def test_head_returns_none_for_an_unpublished_object(fake_session):
+    fake_session(FakeResponse(ok=False, status=403))
+    assert http.head("https://example/missing") is None
+
+
+def test_head_returns_none_when_unreachable(fake_session):
+    fake_session(error=requests.ConnectionError("no network"))
+    assert http.head("https://example/x") is None
+
+
+def test_head_returns_the_response_when_published(fake_session):
+    fake_session(FakeResponse(headers={"Content-Length": "10"}))
+    response = http.head("https://example/x")
+    assert response is not None
+    assert response.headers["Content-Length"] == "10"
+
+
+def test_get_json_returns_the_decoded_body(fake_session):
+    fake_session(FakeResponse(json_data={"refs": [{"ref": "abc"}]}))
+    assert http.get_json("https://example/api")["refs"][0]["ref"] == "abc"
+
+
+def test_get_json_raises_on_an_error_status(fake_session):
+    fake_session(FakeResponse(ok=False, status=500))
+    with pytest.raises(requests.HTTPError):
+        http.get_json("https://example/api")
+
+
+def test_requests_carry_a_timeout(tmp_path, fake_session):
+    session = fake_session(FakeResponse(json_data={}))
+    http.get_json("https://example/api")
+    assert session.calls[0][2]["timeout"] == http.TIMEOUT
+
+
+def test_sessions_are_per_thread():
+    """catalog.resolve HEADs concurrently, and Session is not thread-safe.
+
+    A barrier forces both threads to be live at once; a plain thread pool is
+    free to run two quick tasks on the same worker and would prove nothing.
+    """
+    import threading
+
+    barrier = threading.Barrier(2)
+    ids = []
+    lock = threading.Lock()
+
+    def record():
+        barrier.wait(timeout=5)
+        with lock:
+            ids.append(id(http.session()))
+
+    threads = [threading.Thread(target=record) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert len(set(ids)) == 2
+
+
+def test_session_is_reused_within_one_thread():
+    assert http.session() is http.session()
+
+
+def test_session_sets_the_user_agent():
+    assert http.session().headers["User-Agent"] == http.USER_AGENT


### PR DESCRIPTION
Stacked on #29 (`catalog.py` only exists there), so the base is `cc-catalog-check` and the diff shows only this change. GitHub will retarget to `main` once #29 merges.

You asked whether requests makes the codebase cleaner. It does — but the stronger argument turned out to be that **wget is actively causing bugs**, not just that it's old.

## wget 3.2 was last released 2015-10-22

Still ships Python 2 classifiers, declares no `requires_python`, 628 lines, public domain, no repo activity in a decade. Three concrete defects follow from its implementation:

**1. It stages into the current working directory.**
```python
(fd, tmpfile) = tempfile.mkstemp(".tmp", prefix=prefix, dir=".")
```
`spells add MSH` writes a ~100MB temp file into whatever directory you ran it from, and orphans it there if the transfer dies.

**2. It silently renames when the destination exists — and we ignored the return value.**
```python
if os.path.exists(filename):
    filename = filename_fix_existing(filename)   # -> "name (1).ext"
```
Both call sites did `wget.download(url, out=path)` and discarded the result, then used `path`. So a re-download went to `name (1).ext` while the caller read the **stale** file.

Not hypothetical — there are four of these in the local data home right now:
```
ratings/DSK/PremierDraft_top_BRG_2024-10-08_2025-10-14 (1).json
ratings/DSK/PremierDraft_top_UBR_...  (1).json
ratings/DSK/PremierDraft_top_WUB_...  (1).json
ratings/DSK/PremierDraft_top_WUG_...  (1).json
```
Each has its intended counterpart present, so those four downloads were fetched, written somewhere nobody reads, and discarded. (They're pre-0.14 legacy files, so no live impact — but the mechanism is real.)

**3. No timeout.** It wraps `urlretrieve`, which takes none. A hung connection stalls the 4am cron forever.

Worth noting one thing I expected to find and didn't: wget's progress bar *can* be silenced with `bar=None`, so it was not a blocker for the Phase 5 `--quiet` rule. I checked rather than assumed.

## What replaces it

New `spells/http.py` — one place for user agent, timeout, and retry policy, shared by all four call sites. Previously those were split across three idioms: wget in `external.py` and `card_data_files.py`, `urllib.request` in `cards.py`, and (from #29) `urllib.request` in `catalog.py`.

- `download()` streams to `path.part` **in the destination directory** and `os.replace()`s it into place, so an interrupted transfer can't leave a truncated file that later looks complete to `spells status`. On failure the partial is removed and any existing target is left untouched.
- Progress moves to `rich.progress` — already a dependency via typer, so it matches the CLI's visual language and takes a `progress=False` for the small JSON fetches.
- Retries (3, backoff, 429/5xx, GET+HEAD only) — new capability; wget had none, and both S3 and the Prismic CDN are occasionally flaky under an unattended run.
- Sessions are **thread-local**, because `catalog.resolve` HEADs concurrently and `requests.Session` isn't documented as thread-safe.

## Dependency trade

`wget>=3.2` out, `requests>=2.32` in. That's +4 transitive runtime deps for users (urllib3, certifi, charset-normalizer, idna) against one unmaintained one. Per your standing view that the cost is downstream vetting burden rather than your own runtime: requests is about as pre-vetted as a Python package gets.

It also resolved the pre-existing `spells/cards.py:3` unused-import lint I flagged on #29 — `re` and `urllib.request` are both gone now, so `ruff check` is clean across the repo.

## Testing

196 passing (15 new in `tests/http_test.py`, which assert precisely the wget behaviors above: exact-path write, overwrite-not-rename, staging location, no residue on failure, target preserved on failure, timeout present, per-thread sessions). Existing mocks moved from `wget.download` to `http.download`.

Verified live against a real 17Lands S3 object: progress bar renders, cwd stays empty, re-download overwrites instead of producing `dungeon (1).csv`. `spells check MSH` still runs clean in ~1.3s through the new layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)