### PR TITLE
Stop reporting draft logs under a single set

### DIFF
--- a/spells/cli.py
+++ b/spells/cli.py
@@ -161,7 +161,9 @@ def _render_status(
 
     console.print(Padding(table, (0, 0, 0, 2)))
 
-    if inv.draft_logs:
+    # cached draft logs are keyed by draft id alone, so they cannot be
+    # attributed to the set being reported on
+    if inv.draft_logs and not detailed:
         console.print(
             f"\n  {inv.draft_logs} cached draft logs "
             f"[dim]({sizeof_fmt(inv.draft_log_bytes)})[/dim]"

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -182,3 +182,13 @@ def test_path_reports_store_dir(data_home):
 def test_path_reports_store_set_dir(data_home):
     result = runner.invoke(cli.app, ["path", "TST", "--kind", "cache"])
     assert result.stdout.strip() == str(data_home / "cache" / "TST")
+
+
+def test_status_omits_draft_logs_when_reporting_on_one_set(data_home):
+    """Cached logs are keyed by draft id with no set attribution, so showing a
+    count under `status TST` implies an association that does not exist."""
+    (data_home / "draft").mkdir()
+    (data_home / "draft" / "abc123.json").write_bytes(b"x" * 10)
+
+    assert "cached draft logs" in runner.invoke(cli.app, ["status"]).stdout
+    assert "cached draft logs" not in runner.invoke(cli.app, ["status", "TST"]).stdout


### PR DESCRIPTION
Bug in already-merged code (#28), so this branches off `main` and can merge independently of #29/#30.

## The bug

`spells status MSH` printed `3 cached draft logs (1.1MiB)` — and so did `spells status BLB`, and every other set. Cached logs live in one flat directory keyed by draft id:

```
~/.local/share/spells/draft/
  9b74b1a5ea8349039dc532964dc89c91.json
  9f0fb7a95e39465dac67c6d559c53dd8.json
  9f90672b1456438aa0860ad554f05a57.json
```

Nothing in the filename ties one to a set, so the count was the same total regardless of the argument — implying an association that doesn't exist.

## Why exclude rather than attribute

The payloads *do* carry an `expansion` key at top level, so filtering is possible in principle. But `inventory.scan()` is deliberately a pure `os.scandir` walk — `status`, `check`, and (later) `doctor` are all renderings of that one pass, and they depend on it being cheap. Attributing logs would mean opening and JSON-parsing every cached draft on every invocation; fine at 3 files, not at 300.

If per-set attribution is ever wanted, the right place is the filename at write time (`{expansion}_{draft_id}.json`), which the scan would then pick up for free. Noted in the commit body rather than done here.

## Change

One condition, plus a regression test asserting the line appears in the whole-data-home view and not in the single-set view.

149 tests passing, ruff clean.