### PR TITLE
Add a cards command and stop tracebacks reaching the user

### DIFF
--- a/spells/cards.py
+++ b/spells/cards.py
@@ -141,6 +141,29 @@ def names_from_parquet(draft_set_code: str, event_type: EventType) -> list[str]:
 BASIC_LANDS = frozenset({"Plains", "Island", "Swamp", "Mountain", "Forest"})
 
 
+class CardFileMismatch(ValueError):
+    """The card file on disk describes a different set of cards than the draft
+    data does.
+
+    Carries both sides so a caller can say which is which; formatting a
+    readable summary is the caller's job, since the lists run to hundreds of
+    names when the wrong set is compared.
+    """
+
+    def __init__(
+        self, set_code: str, only_in_data: list[str], only_in_file: list[str]
+    ):
+        self.set_code = set_code
+        self.only_in_data = only_in_data
+        self.only_in_file = only_in_file
+        super().__init__(
+            f"Card list for {set_code} is inconsistent with the existing file "
+            f"({len(only_in_data)} only in draft data, "
+            f"{len(only_in_file)} only in card file). "
+            f"Run `spells cards {set_code} --rebuild` to regenerate."
+        )
+
+
 def write_card_file(
     draft_set_code: str,
     names: list[str],
@@ -165,12 +188,10 @@ def write_card_file(
         existing = frozenset(pl.read_parquet(card_filepath)["name"].to_list())
         incoming = frozenset(names)
         if existing != incoming:
-            added = sorted(incoming - existing)
-            removed = sorted(existing - incoming)
-            raise ValueError(
-                f"Card list for {draft_set_code} is inconsistent with existing file "
-                f"(added={added}, removed={removed}). "
-                f"Run `spells refresh {draft_set_code}` to regenerate."
+            raise CardFileMismatch(
+                draft_set_code,
+                only_in_data=sorted(incoming - existing),
+                only_in_file=sorted(existing - incoming),
             )
         cache.spells_print(mode, f"Card file validated ({len(names)} cards match)")
         return 1

--- a/spells/cli.py
+++ b/spells/cli.py
@@ -9,7 +9,7 @@ from rich.console import Console
 from rich.padding import Padding
 from rich.table import Table
 
-from spells import cache, catalog, external, inventory
+from spells import cache, cards as cards_module, catalog, external, inventory
 from spells.cache import DataDir
 from spells.catalog import Freshness, Target
 from spells import repair
@@ -57,6 +57,43 @@ def _confirm(action: str, yes: bool) -> None:
         raise typer.Exit(2)
     if not typer.confirm(f"{action[0].upper()}{action[1:]}?"):
         raise typer.Exit(2)
+
+
+NAMES_SHOWN = 6
+
+
+def _name_sample(names: list[str]) -> str:
+    shown = ", ".join(names[:NAMES_SHOWN])
+    rest = len(names) - NAMES_SHOWN
+    return f"{shown}, +{rest} more" if rest > 0 else shown
+
+
+def _guard_card_file(action, *args, **kwargs) -> int:
+    """Present a card-file mismatch as an error rather than a traceback.
+
+    Comparing the wrong set puts hundreds of names on each side, so the counts
+    lead and only a sample of each is printed.
+    """
+    try:
+        return action(*args, **kwargs)
+    except cards_module.CardFileMismatch as e:
+        err_console.print(
+            f"[red]Card file for {e.set_code} does not match the draft data.[/red]"
+        )
+        if e.only_in_data:
+            err_console.print(
+                f"  {len(e.only_in_data)} only in draft data: "
+                f"{_name_sample(e.only_in_data)}"
+            )
+        if e.only_in_file:
+            err_console.print(
+                f"  {len(e.only_in_file)} only in card file: "
+                f"{_name_sample(e.only_in_file)}"
+            )
+        err_console.print(
+            f"\n  Run `spells cards {e.set_code} --rebuild` to regenerate it."
+        )
+        raise typer.Exit(1)
 
 
 def _anomaly_dict(anomaly: Anomaly) -> dict:
@@ -266,8 +303,10 @@ def add(
 ) -> None:
     """Download draft, game, and card files, skipping any already present."""
     if card_only:
-        raise typer.Exit(external._add_card_only(set_code, event_type=event_type))
-    raise typer.Exit(external._add(set_code, event_type=event_type))
+        raise typer.Exit(
+            _guard_card_file(external._add_card_only, set_code, event_type=event_type)
+        )
+    raise typer.Exit(_guard_card_file(external._add, set_code, event_type=event_type))
 
 
 @app.command()
@@ -284,8 +323,14 @@ def refresh(
 ) -> None:
     """Re-download and overwrite existing files. Use sparingly."""
     if card_only:
-        raise typer.Exit(external._refresh_card_only(set_code, event_type=event_type))
-    raise typer.Exit(external._refresh(set_code, event_type=event_type))
+        raise typer.Exit(
+            _guard_card_file(
+                external._refresh_card_only, set_code, event_type=event_type
+            )
+        )
+    raise typer.Exit(
+        _guard_card_file(external._refresh, set_code, event_type=event_type)
+    )
 
 
 @app.command()
@@ -536,6 +581,27 @@ def check(
 
     if any(_is_actionable(r, held) for r in rows):
         raise typer.Exit(3)
+
+
+@app.command()
+def cards(
+    set_code: str,
+    event_type: Annotated[EventType, typer.Argument()] = EventType.PREMIER,
+    rebuild: Annotated[
+        bool,
+        typer.Option("--rebuild", help="Regenerate from MTGJSON, discarding the file."),
+    ] = False,
+) -> None:
+    """Check the card file against downloaded draft data, or rebuild it."""
+    if rebuild:
+        raise typer.Exit(
+            _guard_card_file(
+                external._refresh_card_only, set_code, event_type=event_type
+            )
+        )
+    raise typer.Exit(
+        _guard_card_file(external._add_card_only, set_code, event_type=event_type)
+    )
 
 
 @app.command()

--- a/spells/external.py
+++ b/spells/external.py
@@ -69,7 +69,8 @@ def _add_card_only(set_code: str, event_type: EventType) -> int:
 
     # no force_download: builds the file if missing, validates and raises on
     # mismatch if it already exists — a spot check, not a rebuild
-    return cards.write_card_file(set_code, names)
+    cards.write_card_file(set_code, names)
+    return 0
 
 
 def _refresh(set_code: str, event_type: EventType):

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -447,3 +447,123 @@ def test_doctor_json_never_prompts_even_at_a_terminal(snapshots, at_a_terminal):
     assert result.exit_code == 0
     json.loads(result.stdout)
     assert (snapshots / LEGACY_SNAPSHOT).exists()
+
+
+# ---------------------------------------------------------------------------
+# cards
+# ---------------------------------------------------------------------------
+
+
+import polars as pl  # noqa: E402
+
+from spells import cards as cards_module  # noqa: E402
+
+BASICS = ["Plains", "Island", "Swamp", "Mountain", "Forest"]
+
+
+@pytest.fixture
+def card_set(data_home):
+    """Real parquets: the card commands read them, unlike the stub files the
+    scanner tests get away with."""
+
+    def build(draft_names, card_names):
+        d = data_home / "external" / "TST"
+        d.mkdir(parents=True, exist_ok=True)
+        pl.DataFrame({f"pack_card_{n}": [1] for n in draft_names}).write_parquet(
+            d / "TST_PremierDraft_draft.parquet"
+        )
+        if card_names is not None:
+            pl.DataFrame({"name": sorted(set(card_names) | set(BASICS))}).write_parquet(
+                d / "TST_card.parquet"
+            )
+        return d
+
+    return build
+
+
+def test_cards_validates_a_consistent_file(card_set):
+    """Exit 0: a card file that checks out is success, not a runtime error."""
+    card_set(["Alpha", "Beta"], ["Alpha", "Beta"])
+
+    result = runner.invoke(cli.app, ["cards", "TST"])
+    assert result.exit_code == 0
+    assert "validated" in result.output
+
+
+def test_cards_reports_a_mismatch_without_a_traceback(card_set):
+    card_set(["Alpha", "Gamma"], ["Alpha", "Delta"])
+
+    result = runner.invoke(cli.app, ["cards", "TST"])
+
+    assert result.exit_code == 1
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    assert "Traceback" not in result.output
+    assert "does not match" in result.output
+    assert "Gamma" in result.output and "Delta" in result.output
+
+
+def test_cards_mismatch_names_the_side_each_difference_came_from(card_set):
+    card_set(["Alpha", "Gamma"], ["Alpha", "Delta"])
+
+    out = runner.invoke(cli.app, ["cards", "TST"]).output
+    assert "1 only in draft data" in out
+    assert "1 only in card file" in out
+
+
+def test_cards_mismatch_truncates_long_name_lists(card_set):
+    """Comparing the wrong set puts hundreds of names on each side."""
+    card_set(
+        [f"Card{i:03d}" for i in range(200)], [f"Other{i:03d}" for i in range(150)]
+    )
+
+    out = runner.invoke(cli.app, ["cards", "TST"]).output
+    assert "200 only in draft data" in out
+    assert "more" in out
+    assert out.count("Card0") <= cli.NAMES_SHOWN
+
+
+def test_cards_reports_a_missing_draft_file(card_set):
+    result = runner.invoke(cli.app, ["cards", "NOPE"])
+    assert result.exit_code == 1
+    assert "Traceback" not in result.output
+
+
+def test_cards_rebuild_dispatches_to_the_rebuild_path(monkeypatch, card_set):
+    calls = []
+    monkeypatch.setattr(
+        external,
+        "_refresh_card_only",
+        lambda set_code, event_type: calls.append((set_code, event_type)) or 0,
+    )
+    result = runner.invoke(cli.app, ["cards", "TST", "--rebuild"])
+
+    assert result.exit_code == 0
+    assert calls == [("TST", EventType.PREMIER)]
+
+
+def test_cards_takes_an_event_type(monkeypatch, card_set):
+    calls = []
+    monkeypatch.setattr(
+        external,
+        "_add_card_only",
+        lambda set_code, event_type: calls.append(event_type) or 0,
+    )
+    runner.invoke(cli.app, ["cards", "TST", "TradDraft"])
+    assert calls == [EventType.TRADITIONAL]
+
+
+def test_add_presents_a_card_mismatch_cleanly(card_set):
+    """The guard covers every entry point, not just `cards`."""
+    card_set(["Alpha", "Gamma"], ["Alpha", "Delta"])
+
+    result = runner.invoke(cli.app, ["add", "TST", "--card-only"])
+    assert result.exit_code == 1
+    assert "does not match" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_mismatch_error_carries_both_sides():
+    e = cards_module.CardFileMismatch("TST", ["a"], ["b", "c"])
+    assert e.only_in_data == ["a"]
+    assert e.only_in_file == ["b", "c"]
+    assert "TST" in str(e)

--- a/tests/external_test.py
+++ b/tests/external_test.py
@@ -124,7 +124,9 @@ def test_add_card_only_validates_consistent_file(tmp_path, monkeypatch):
         external.cards, "names_from_parquet", lambda set_code, event_type: FAKE_NAMES
     )
 
-    assert external._add_card_only("TST", event_type=EventType.PREMIER) == 1
+    # 0, not 1: this value becomes the process exit code, and a card file
+    # that checks out is success rather than a runtime error
+    assert external._add_card_only("TST", event_type=EventType.PREMIER) == 0
 
 
 def test_add_card_only_raises_on_mismatch_rather_than_overwriting(


### PR DESCRIPTION
Phase 3 of `.claude/plans/spells-cli-file-management.md`.

## The failure this fixes

A card list disagreeing with the draft data raised out of `cards.py` and reached the user as a **full rich traceback** — stack frame, source excerpt, the lot. The plan called it "a bare ValueError"; it was worse than that, and reads as a crash rather than a user error.

Before:

```
│ /home/joel/dev/spells/spells/cards.py:170 in write_card_file                 │
│   167 │   │   if existing != incoming:                                       │
│   168 │   │   │   added = sorted(incoming - existing)                        │
│ ❱ 170 │   │   │   raise ValueError(                                          │
╰──────────────────────────────────────────────────────────────────────────────╯
ValueError: Card list for TST is inconsistent with existing file (added=[...
```

After:

```
Card file for TST does not match the draft data.
  1 only in draft data: Gamma
  1 only in card file: Delta

  Run `spells cards TST --rebuild` to regenerate it.
```

The mismatch is now a typed `CardFileMismatch` carrying both sides separately, so the CLI can say which names came from where. **Counts lead and only a few names are sampled** — comparing the wrong set puts hundreds on each side, and the old message inlined both lists in full:

```
  200 only in draft data: Card000, Card001, Card002, Card003, Card004, Card005, +194 more
  150 only in card file: Other000, Other001, Other002, Other003, Other004, Other005, +144 more
```

Every entry point that writes a card file goes through the same guard, so `add --card-only` and `refresh` report it identically rather than only `cards`.

## New command

```
spells cards SET [EVENT_TYPE] [--rebuild]
```

Checks by default, rebuilds on request — promoting what was `--card-only` to a command of its own. The old spellings still work, per the plan ("no deprecation warning, it's just no longer the discoverable spelling").

The plan specified `[--check | --rebuild]`; checking is the default, so `--check` would only ever mean "do the thing you were going to do anyway". Same reasoning that folded `--execute` into `--yes` in #32.

## Exit-code bug found along the way

`_add_card_only` returned `write_card_file`'s value, which is `0` for "wrote the file" and `1` for "validated an existing one". That distinction is meaningful to a library caller, but it was becoming the **process exit status** — so a card file that checked out perfectly reported exit 1, and `spells cards MSH && echo ok` could never chain.

Verified against the real data home: `spells cards MSH` was exit 1 on 339 valid cards, now exit 0. `write_card_file`'s own 0/1 contract is unchanged.

One pre-existing test asserted the old value and has been updated with the reason inline. The neighbouring `test_add_card_only_requires_existing_draft_file` still asserts 1 — a genuinely missing draft file *is* a runtime error.

## Testing

**239 passing**, ruff clean. 9 new CLI tests using real parquet fixtures (the stub files the scanner tests use aren't readable by polars): consistent-file validation exits 0, mismatch exits 1 with no traceback, both sides are labelled, long lists truncate, missing draft file is clean, `--rebuild` and the event-type argument dispatch correctly, and `add --card-only` presents the same error.