### PR TITLE
Route terminal output through one writer

### DIFF
--- a/spells/cache.py
+++ b/spells/cache.py
@@ -275,8 +275,6 @@ def write_cache(set_code: str, cache_key: str, df: pl.DataFrame) -> None:
 
 
 def clean(set_code: str) -> int:
-    mode = "clean"
-
     if set_code == "all":
         cache_dir = data_dir_path(DataDir.CACHE)
         with os.scandir(cache_dir) as set_dir:
@@ -291,18 +289,15 @@ def clean(set_code: str) -> int:
             for entry in set_dir:
                 if not entry.name.endswith(".parquet"):
                     console.info(
-                        mode,
                         f"Unexpected file {entry.name} found in local cache, please sort that out!",
                     )
                     return 1
                 count += 1
                 os.remove(entry)
-            console.info(
-                mode, f"Removed {count} files from local cache for set {set_code}"
-            )
+            console.info(f"Removed {count} files from local cache for set {set_code}")
         os.rmdir(cache_dir)
-        console.info(mode, f"Removed local cache dir {cache_dir}")
+        console.info(f"Removed local cache dir {cache_dir}")
         return 0
     else:
-        console.info(mode, f"No local cache found for set {set_code}")
+        console.info(f"No local cache found for set {set_code}")
         return 0

--- a/spells/cache.py
+++ b/spells/cache.py
@@ -13,6 +13,8 @@ import os
 from pathlib import Path
 import sys
 
+from spells import console
+
 import polars as pl
 
 from spells.enums import EventType, TimePeriod
@@ -32,10 +34,6 @@ class DataDir(StrEnum):
     RATINGS = "ratings"
     DECK_COLOR = "deck_color"
     DRAFT = "draft"
-
-
-def spells_print(mode, content):
-    print(f"  🪄 {mode} ✨ {content}")
 
 
 def set_test_env():
@@ -292,19 +290,19 @@ def clean(set_code: str) -> int:
             count = 0
             for entry in set_dir:
                 if not entry.name.endswith(".parquet"):
-                    spells_print(
+                    console.info(
                         mode,
                         f"Unexpected file {entry.name} found in local cache, please sort that out!",
                     )
                     return 1
                 count += 1
                 os.remove(entry)
-            spells_print(
+            console.info(
                 mode, f"Removed {count} files from local cache for set {set_code}"
             )
         os.rmdir(cache_dir)
-        spells_print(mode, f"Removed local cache dir {cache_dir}")
+        console.info(mode, f"Removed local cache dir {cache_dir}")
         return 0
     else:
-        spells_print(mode, f"No local cache found for set {set_code}")
+        console.info(mode, f"No local cache found for set {set_code}")
         return 0

--- a/spells/cards.py
+++ b/spells/cards.py
@@ -5,6 +5,7 @@ from enum import StrEnum
 import polars as pl
 
 from spells import cache
+from spells import console
 from spells import http
 from spells.enums import ColName, View, EventType
 
@@ -150,9 +151,7 @@ class CardFileMismatch(ValueError):
     names when the wrong set is compared.
     """
 
-    def __init__(
-        self, set_code: str, only_in_data: list[str], only_in_file: list[str]
-    ):
+    def __init__(self, set_code: str, only_in_data: list[str], only_in_file: list[str]):
         self.set_code = set_code
         self.only_in_data = only_in_data
         self.only_in_file = only_in_file
@@ -193,14 +192,12 @@ def write_card_file(
                 only_in_data=sorted(incoming - existing),
                 only_in_file=sorted(existing - incoming),
             )
-        cache.spells_print(mode, f"Card file validated ({len(names)} cards match)")
+        console.info(mode, f"Card file validated ({len(names)} cards match)")
         return 1
 
-    cache.spells_print(
-        mode, "Fetching card data from mtgjson.com and writing card file"
-    )
+    console.info(mode, "Fetching card data from mtgjson.com and writing card file")
     df = card_df(draft_set_code, names)
     os.makedirs(os.path.dirname(card_filepath), exist_ok=True)
     df.write_parquet(card_filepath)
-    cache.spells_print(mode, f"Wrote file {card_filepath}")
+    console.info(mode, f"Wrote file {card_filepath}")
     return 0

--- a/spells/cards.py
+++ b/spells/cards.py
@@ -180,7 +180,6 @@ def write_card_file(
     always overwrites.
     """
     names = sorted(set(names) | BASIC_LANDS)
-    mode = "refresh" if force_download else "add"
     card_filepath = cache.data_file_path(draft_set_code, View.CARD)
 
     if os.path.isfile(card_filepath) and not force_download:
@@ -192,12 +191,12 @@ def write_card_file(
                 only_in_data=sorted(incoming - existing),
                 only_in_file=sorted(existing - incoming),
             )
-        console.info(mode, f"Card file validated ({len(names)} cards match)")
+        console.info(f"Card file validated ({len(names)} cards match)")
         return 1
 
-    console.info(mode, "Fetching card data from mtgjson.com and writing card file")
+    console.info("Fetching card data from mtgjson.com and writing card file")
     df = card_df(draft_set_code, names)
     os.makedirs(os.path.dirname(card_filepath), exist_ok=True)
     df.write_parquet(card_filepath)
-    console.info(mode, f"Wrote file {card_filepath}")
+    console.info(f"Wrote file {card_filepath}")
     return 0

--- a/spells/cli.py
+++ b/spells/cli.py
@@ -10,6 +10,7 @@ from rich.padding import Padding
 from rich.table import Table
 
 from spells import cache, cards as cards_module, catalog, external, inventory
+from spells import console as spells_console
 from spells.cache import DataDir
 from spells.catalog import Freshness, Target
 from spells import repair
@@ -246,7 +247,14 @@ def _render_status(
 
 
 @app.callback(invoke_without_command=True)
-def main(ctx: typer.Context) -> None:
+def main(
+    ctx: typer.Context,
+    quiet: Annotated[
+        bool,
+        typer.Option("--quiet", "-q", help="Suppress progress. Errors still print."),
+    ] = False,
+) -> None:
+    spells_console.set_quiet(quiet)
     if ctx.invoked_subcommand is None:
         status()
 

--- a/spells/console.py
+++ b/spells/console.py
@@ -27,10 +27,15 @@ def is_quiet() -> bool:
     return _quiet
 
 
-def info(mode: str, content: str) -> None:
-    """Progress, suppressed by --quiet."""
+def info(content: str) -> None:
+    """Progress, suppressed by --quiet.
+
+    No prefix: the command the user typed already says what is happening, and
+    the old one named the internal function rather than the command, so
+    `spells cards` announced itself as `add`.
+    """
     if not _quiet:
-        _out.print(f"  🪄 [bold]{mode}[/bold] ✨ {content}", soft_wrap=True)
+        _out.print(f"  {content}", soft_wrap=True)
 
 
 def detail(content: str) -> None:

--- a/spells/console.py
+++ b/spells/console.py
@@ -1,0 +1,44 @@
+"""The one place spells writes to a terminal.
+
+Bare `print` is block-buffered when stdout is a pipe, so progress written that
+way arrived after errors written to stderr, interleaving the two out of order.
+Routing both through rich also gets `NO_COLOR` and non-terminal detection for
+free.
+
+Library diagnostics do not belong here — those go to `logging`, which already
+has a rotating file handler, so that a warning meant for whoever is writing an
+extension is not mixed into a user's progress output.
+"""
+
+from rich.console import Console
+
+_out = Console()
+_err = Console(stderr=True)
+
+_quiet = False
+
+
+def set_quiet(quiet: bool) -> None:
+    global _quiet
+    _quiet = quiet
+
+
+def is_quiet() -> bool:
+    return _quiet
+
+
+def info(mode: str, content: str) -> None:
+    """Progress, suppressed by --quiet."""
+    if not _quiet:
+        _out.print(f"  🪄 [bold]{mode}[/bold] ✨ {content}", soft_wrap=True)
+
+
+def detail(content: str) -> None:
+    """A continuation line under the preceding `info`."""
+    if not _quiet:
+        _out.print(f"      {content}", soft_wrap=True)
+
+
+def error(content: str) -> None:
+    """Failures, on stderr and never suppressed."""
+    _err.print(f"[red]{content}[/red]", soft_wrap=True)

--- a/spells/draft_data.py
+++ b/spells/draft_data.py
@@ -302,8 +302,11 @@ def _hydrate_col_defs(
             if spec.version is not None:
                 expr_sig = col + spec.version
             else:
-                print(
-                    f"Using session-only signature for non-serializable column {col}, please provide a version value"
+                logging.warning(
+                    "Column %s has a non-serializable expression and no version, "
+                    "so its cache signature is session-only and nothing will be "
+                    "reused across runs. Set `version` on its ColSpec.",
+                    col,
                 )
                 expr_sig = str(sig_expr)
 

--- a/spells/draft_model.py
+++ b/spells/draft_model.py
@@ -21,6 +21,7 @@ import itertools
 import polars as pl
 
 from spells import cache
+from spells import console
 from spells.card_data_files import download_data_file
 from spells.cards import card_df, write_card_file, names_from_parquet
 from spells.draft_data import lazy_select
@@ -132,7 +133,7 @@ def _card_attr_map(expansion: str, names: list[str]) -> dict[str, dict]:
         try:
             df = card_df(expansion, names)
         except Exception:
-            cache.spells_print("draft", f"No card data available for {expansion}")
+            console.info("draft", f"No card data available for {expansion}")
             return {}
 
     return {row[ColName.NAME]: row for row in df.to_dicts()}

--- a/spells/draft_model.py
+++ b/spells/draft_model.py
@@ -133,7 +133,7 @@ def _card_attr_map(expansion: str, names: list[str]) -> dict[str, dict]:
         try:
             df = card_df(expansion, names)
         except Exception:
-            console.info("draft", f"No card data available for {expansion}")
+            console.info(f"No card data available for {expansion}")
             return {}
 
     return {row[ColName.NAME]: row for row in df.to_dicts()}

--- a/spells/extension.py
+++ b/spells/extension.py
@@ -10,7 +10,7 @@ from spells import console
 
 
 def print_ext(ext: dict[str, ColSpec]) -> None:
-    console.info("create", "Created extensions:")
+    console.info("Created extensions:")
     for key in ext:
         console.detail(key)
 

--- a/spells/extension.py
+++ b/spells/extension.py
@@ -6,13 +6,13 @@ import polars as pl
 
 from spells.enums import ColType, ColName
 from spells.columns import ColSpec
-from spells.cache import spells_print
+from spells import console
 
 
 def print_ext(ext: dict[str, ColSpec]) -> None:
-    spells_print("create", "Created extensions:")
+    console.info("create", "Created extensions:")
     for key in ext:
-        print("\t" + key)
+        console.detail(key)
 
 
 def seen_greatest_name_fn(attr: str) -> Callable:

--- a/spells/external.py
+++ b/spells/external.py
@@ -31,9 +31,9 @@ def _add(
     event_type: EventType,
     force_download: bool = False,
 ) -> int:
-    mode = "refresh" if force_download else "add"
     console.info(
-        mode, f"Adding {set_code} {event_type} to {cache.external_set_path(set_code)}"
+        f"{'Refreshing' if force_download else 'Adding'} {set_code} {event_type} "
+        f"in {cache.external_set_path(set_code)}",
     )
 
     download_data_set(
@@ -47,7 +47,6 @@ def _add(
 
     if event_type == EventType.PICK_TWO:
         console.info(
-            "add",
             f"Skipping set context for {event_type} "
             "(summon does not support multi-pick formats yet)",
         )
@@ -57,15 +56,13 @@ def _add(
 
 
 def _add_card_only(set_code: str, event_type: EventType) -> int:
-    mode = "add"
     console.info(
-        mode,
         f"Checking card file for {set_code} against existing {event_type} draft data",
     )
     try:
         names = cards.names_from_parquet(set_code, event_type)
     except FileNotFoundError as e:
-        console.info("error", str(e))
+        console.error(str(e))
         return 1
 
     # no force_download: builds the file if missing, validates and raises on
@@ -79,15 +76,13 @@ def _refresh(set_code: str, event_type: EventType):
 
 
 def _refresh_card_only(set_code: str, event_type: EventType) -> int:
-    mode = "refresh"
     console.info(
-        mode,
         f"Rebuilding card file for {set_code} from existing {event_type} draft data",
     )
     try:
         names = cards.names_from_parquet(set_code, event_type)
     except FileNotFoundError as e:
-        console.info("error", str(e))
+        console.error(str(e))
         return 1
 
     cards.write_card_file(set_code, names, force_download=True)
@@ -96,7 +91,6 @@ def _refresh_card_only(set_code: str, event_type: EventType) -> int:
 
 
 def _remove(set_code: str):
-    mode = "remove"
     dir_path = cache.external_set_path(set_code)
     if os.path.isdir(dir_path):
         with os.scandir(dir_path) as set_dir:
@@ -104,18 +98,17 @@ def _remove(set_code: str):
             for entry in set_dir:
                 if not entry.name.endswith(".parquet"):
                     console.info(
-                        mode,
                         f"Unexpected file {entry.name} found in external cache, please sort that out!",
                     )
                     return 1
                 count += 1
                 os.remove(entry)
             console.info(
-                mode, f"Removed {count} files from external cache for set {set_code}"
+                f"Removed {count} files from external cache for set {set_code}"
             )
         os.rmdir(dir_path)
     else:
-        console.info(mode, f"No external cache found for set {set_code}")
+        console.info(f"No external cache found for set {set_code}")
 
     return cache.clean(set_code)
 
@@ -135,9 +128,8 @@ def _process_zipped_file(gzip_path, target_path):
     except ComputeError:
         df = pl.scan_csv(csv_path)
         console.info(
-            "error",
-            "Bad schema found, loading dataset into memory"
-            + " and attempting to cast to correct schema",
+            "Bad schema found, loading dataset into memory "
+            "and attempting to cast to the correct schema"
         )
         select = [pl.col(name).cast(dtype) for name, dtype in schema(csv_path).items()]
         cast_df = df.select(select).collect()
@@ -153,9 +145,7 @@ def download_data_set(
     force_download=False,
     clear_set_cache=True,
 ):
-    mode = "refresh" if force_download else "add"
     console.info(
-        mode,
         f"Downloading {set_code} {event_type} {dataset_type} dataset from 17Lands.com",
     )
 
@@ -166,7 +156,6 @@ def download_data_set(
 
     if os.path.isfile(target_path) and not force_download:
         console.info(
-            mode,
             f"File {target_path} already exists, use `spells refresh {set_code}` to overwrite",
         )
         return 1
@@ -176,14 +165,14 @@ def download_data_set(
     )
     source_url = RESOURCE_TEMPLATE.format(dataset_type=dataset_type) + dataset_file
     dataset_path = os.path.join(cache.external_set_path(set_code), dataset_file)
-    console.info(mode, f"Fetching {source_url}")
+    console.info(f"Fetching {source_url}")
     http.download(source_url, dataset_path, description=dataset_file)
 
     console.info(
-        mode, "Unzipping and transforming to parquet (this might take a few minutes)..."
+        "Unzipping and transforming to parquet (this might take a few minutes)..."
     )
     _process_zipped_file(dataset_path, target_path)
-    console.info(mode, f"Wrote file {target_path}")
+    console.info(f"Wrote file {target_path}")
     if clear_set_cache:
         cache.clean(set_code)
 
@@ -195,13 +184,10 @@ def get_set_context(
     event_type: EventType,
     force_download=False,
 ) -> int:
-    mode = "refresh" if force_download else "add"
-
     context_fp = cache.data_file_path(set_code, "context", event_type)
-    console.info(mode, "Calculating set context")
+    console.info("Calculating set context")
     if os.path.isfile(context_fp) and not force_download:
         console.info(
-            mode,
             f"File {context_fp} already exists, use `spells refresh {set_code}` to overwrite",
         )
         return 1
@@ -222,6 +208,6 @@ def get_set_context(
 
     context_df.write_parquet(context_fp)
 
-    console.info(mode, f"Wrote file {context_fp}")
+    console.info(f"Wrote file {context_fp}")
 
     return 0

--- a/spells/external.py
+++ b/spells/external.py
@@ -13,6 +13,7 @@ from polars.exceptions import ComputeError
 
 from spells import cards
 from spells import cache
+from spells import console
 from spells import http
 from spells.catalog import DATASET_TEMPLATE, RESOURCE_TEMPLATE
 from spells.enums import View, ColName, EventType
@@ -31,7 +32,7 @@ def _add(
     force_download: bool = False,
 ) -> int:
     mode = "refresh" if force_download else "add"
-    cache.spells_print(
+    console.info(
         mode, f"Adding {set_code} {event_type} to {cache.external_set_path(set_code)}"
     )
 
@@ -45,7 +46,7 @@ def _add(
     )
 
     if event_type == EventType.PICK_TWO:
-        cache.spells_print(
+        console.info(
             "add",
             f"Skipping set context for {event_type} "
             "(summon does not support multi-pick formats yet)",
@@ -57,14 +58,14 @@ def _add(
 
 def _add_card_only(set_code: str, event_type: EventType) -> int:
     mode = "add"
-    cache.spells_print(
+    console.info(
         mode,
         f"Checking card file for {set_code} against existing {event_type} draft data",
     )
     try:
         names = cards.names_from_parquet(set_code, event_type)
     except FileNotFoundError as e:
-        cache.spells_print("error", str(e))
+        console.info("error", str(e))
         return 1
 
     # no force_download: builds the file if missing, validates and raises on
@@ -79,14 +80,14 @@ def _refresh(set_code: str, event_type: EventType):
 
 def _refresh_card_only(set_code: str, event_type: EventType) -> int:
     mode = "refresh"
-    cache.spells_print(
+    console.info(
         mode,
         f"Rebuilding card file for {set_code} from existing {event_type} draft data",
     )
     try:
         names = cards.names_from_parquet(set_code, event_type)
     except FileNotFoundError as e:
-        cache.spells_print("error", str(e))
+        console.info("error", str(e))
         return 1
 
     cards.write_card_file(set_code, names, force_download=True)
@@ -102,19 +103,19 @@ def _remove(set_code: str):
             count = 0
             for entry in set_dir:
                 if not entry.name.endswith(".parquet"):
-                    cache.spells_print(
+                    console.info(
                         mode,
                         f"Unexpected file {entry.name} found in external cache, please sort that out!",
                     )
                     return 1
                 count += 1
                 os.remove(entry)
-            cache.spells_print(
+            console.info(
                 mode, f"Removed {count} files from external cache for set {set_code}"
             )
         os.rmdir(dir_path)
     else:
-        cache.spells_print(mode, f"No external cache found for set {set_code}")
+        console.info(mode, f"No external cache found for set {set_code}")
 
     return cache.clean(set_code)
 
@@ -133,7 +134,7 @@ def _process_zipped_file(gzip_path, target_path):
         df.sink_parquet(target_path)
     except ComputeError:
         df = pl.scan_csv(csv_path)
-        cache.spells_print(
+        console.info(
             "error",
             "Bad schema found, loading dataset into memory"
             + " and attempting to cast to correct schema",
@@ -153,7 +154,7 @@ def download_data_set(
     clear_set_cache=True,
 ):
     mode = "refresh" if force_download else "add"
-    cache.spells_print(
+    console.info(
         mode,
         f"Downloading {set_code} {event_type} {dataset_type} dataset from 17Lands.com",
     )
@@ -164,7 +165,7 @@ def download_data_set(
     target_path = cache.data_file_path(set_code, dataset_type, event_type)
 
     if os.path.isfile(target_path) and not force_download:
-        cache.spells_print(
+        console.info(
             mode,
             f"File {target_path} already exists, use `spells refresh {set_code}` to overwrite",
         )
@@ -175,14 +176,14 @@ def download_data_set(
     )
     source_url = RESOURCE_TEMPLATE.format(dataset_type=dataset_type) + dataset_file
     dataset_path = os.path.join(cache.external_set_path(set_code), dataset_file)
-    cache.spells_print(mode, f"Fetching {source_url}")
+    console.info(mode, f"Fetching {source_url}")
     http.download(source_url, dataset_path, description=dataset_file)
 
-    cache.spells_print(
+    console.info(
         mode, "Unzipping and transforming to parquet (this might take a few minutes)..."
     )
     _process_zipped_file(dataset_path, target_path)
-    cache.spells_print(mode, f"Wrote file {target_path}")
+    console.info(mode, f"Wrote file {target_path}")
     if clear_set_cache:
         cache.clean(set_code)
 
@@ -197,9 +198,9 @@ def get_set_context(
     mode = "refresh" if force_download else "add"
 
     context_fp = cache.data_file_path(set_code, "context", event_type)
-    cache.spells_print(mode, "Calculating set context")
+    console.info(mode, "Calculating set context")
     if os.path.isfile(context_fp) and not force_download:
-        cache.spells_print(
+        console.info(
             mode,
             f"File {context_fp} already exists, use `spells refresh {set_code}` to overwrite",
         )
@@ -221,6 +222,6 @@ def get_set_context(
 
     context_df.write_parquet(context_fp)
 
-    cache.spells_print(mode, f"Wrote file {context_fp}")
+    console.info(mode, f"Wrote file {context_fp}")
 
     return 0

--- a/spells/manifest.py
+++ b/spells/manifest.py
@@ -139,8 +139,10 @@ def _resolve_view_cols(
                         ), f"Column {col} can't be defined in any views!"
                         for view in col_views:
                             if view not in view_resolution:
-                                print(cdef)
-                                assert False, f"Something went wrong with col {col}"
+                                raise AssertionError(
+                                    f"Column {col} resolved to view {view}, "
+                                    f"which is not in the view resolution: {cdef}"
+                                )
 
                             view_resolution[view] = view_resolution[view].union({col})
                     else:

--- a/spells/schema.py
+++ b/spells/schema.py
@@ -6,6 +6,7 @@
 # converted to use by polars
 
 import csv
+import logging
 import re
 from typing import Dict
 
@@ -153,5 +154,5 @@ def schema(
                 break
             else:
                 if print_missing:
-                    print(f"Could not find an appropriate type for {column}")
+                    logging.warning("No column type matched %s", column)
     return dtypes

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -588,7 +588,7 @@ def test_quiet_suppresses_library_progress(data_home):
     loud = runner.invoke(cli.app, ["clean", "TST"])
     quiet = runner.invoke(cli.app, ["--quiet", "clean", "TST"])
 
-    assert "🪄" in loud.output
+    assert loud.output.strip() != ""
     assert quiet.output.strip() == ""
     assert quiet.exit_code == loud.exit_code
 
@@ -600,4 +600,20 @@ def test_quiet_still_reports_errors(card_set):
 
     assert result.exit_code == 1
     assert "does not match" in result.output
-    assert "🪄" not in result.output
+    assert "Checking card file" not in result.output
+
+
+def test_quiet_does_not_swallow_a_missing_file_error(data_home):
+    """These went through info(), so --quiet reduced them to a bare exit 1."""
+    result = runner.invoke(cli.app, ["--quiet", "cards", "NOPE"])
+
+    assert result.exit_code == 1
+    assert "No PremierDraft draft file for NOPE" in result.output
+
+
+def test_cards_does_not_report_itself_as_add(card_set):
+    card_set(["Alpha"], ["Alpha"])
+
+    output = runner.invoke(cli.app, ["cards", "TST"]).output
+    assert "Checking card file" in output
+    assert "add" not in output.split("Checking")[0]

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -567,3 +567,37 @@ def test_mismatch_error_carries_both_sides():
     assert e.only_in_data == ["a"]
     assert e.only_in_file == ["b", "c"]
     assert "TST" in str(e)
+
+
+# ---------------------------------------------------------------------------
+# --quiet
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _loud():
+    """--quiet is process-global, so a test that sets it must not leak."""
+    from spells import console as spells_console
+
+    spells_console.set_quiet(False)
+    yield
+    spells_console.set_quiet(False)
+
+
+def test_quiet_suppresses_library_progress(data_home):
+    loud = runner.invoke(cli.app, ["clean", "TST"])
+    quiet = runner.invoke(cli.app, ["--quiet", "clean", "TST"])
+
+    assert "🪄" in loud.output
+    assert quiet.output.strip() == ""
+    assert quiet.exit_code == loud.exit_code
+
+
+def test_quiet_still_reports_errors(card_set):
+    card_set(["Alpha", "Gamma"], ["Alpha", "Delta"])
+
+    result = runner.invoke(cli.app, ["--quiet", "cards", "TST"])
+
+    assert result.exit_code == 1
+    assert "does not match" in result.output
+    assert "🪄" not in result.output

--- a/tests/console_test.py
+++ b/tests/console_test.py
@@ -1,0 +1,68 @@
+"""
+Tests for the single output path.
+
+The ordering test is the reason this module exists: bare `print` is
+block-buffered when stdout is a pipe, so progress written that way arrived
+*after* errors written to stderr.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+from spells import console
+
+
+@pytest.fixture(autouse=True)
+def loud():
+    console.set_quiet(False)
+    yield
+    console.set_quiet(False)
+
+
+def test_info_writes_progress(capsys):
+    console.info("add", "downloading")
+    assert "downloading" in capsys.readouterr().out
+
+
+def test_quiet_suppresses_progress(capsys):
+    console.set_quiet(True)
+    console.info("add", "downloading")
+    console.detail("a detail")
+    assert capsys.readouterr().out == ""
+
+
+def test_quiet_never_suppresses_errors(capsys):
+    console.set_quiet(True)
+    console.error("it broke")
+    captured = capsys.readouterr()
+    assert "it broke" in captured.err
+    assert captured.out == ""
+
+
+def test_errors_go_to_stderr_so_stdout_stays_pipeable(capsys):
+    console.info("add", "progress")
+    console.error("failure")
+    captured = capsys.readouterr()
+    assert "progress" in captured.out and "progress" not in captured.err
+    assert "failure" in captured.err and "failure" not in captured.out
+
+
+def test_progress_and_errors_stay_in_order_when_piped(tmp_path):
+    """The regression this module was written for. Needs a real subprocess:
+    capsys does not reproduce the block buffering that caused it."""
+    script = tmp_path / "prog.py"
+    script.write_text(
+        "from spells import console\n"
+        "console.info('add', 'FIRST')\n"
+        "console.error('SECOND')\n"
+    )
+    out = subprocess.run([sys.executable, str(script)], capture_output=True, text=True)
+    merged = out.stdout + out.stderr
+    combined = subprocess.run(
+        f"{sys.executable} {script} 2>&1", shell=True, capture_output=True, text=True
+    ).stdout
+
+    assert "FIRST" in merged and "SECOND" in merged
+    assert combined.index("FIRST") < combined.index("SECOND")

--- a/tests/console_test.py
+++ b/tests/console_test.py
@@ -22,13 +22,13 @@ def loud():
 
 
 def test_info_writes_progress(capsys):
-    console.info("add", "downloading")
+    console.info("downloading")
     assert "downloading" in capsys.readouterr().out
 
 
 def test_quiet_suppresses_progress(capsys):
     console.set_quiet(True)
-    console.info("add", "downloading")
+    console.info("downloading")
     console.detail("a detail")
     assert capsys.readouterr().out == ""
 
@@ -42,7 +42,7 @@ def test_quiet_never_suppresses_errors(capsys):
 
 
 def test_errors_go_to_stderr_so_stdout_stays_pipeable(capsys):
-    console.info("add", "progress")
+    console.info("progress")
     console.error("failure")
     captured = capsys.readouterr()
     assert "progress" in captured.out and "progress" not in captured.err
@@ -55,7 +55,7 @@ def test_progress_and_errors_stay_in_order_when_piped(tmp_path):
     script = tmp_path / "prog.py"
     script.write_text(
         "from spells import console\n"
-        "console.info('add', 'FIRST')\n"
+        "console.info('FIRST')\n"
         "console.error('SECOND')\n"
     )
     out = subprocess.run([sys.executable, str(script)], capture_output=True, text=True)
@@ -66,3 +66,11 @@ def test_progress_and_errors_stay_in_order_when_piped(tmp_path):
 
     assert "FIRST" in merged and "SECOND" in merged
     assert combined.index("FIRST") < combined.index("SECOND")
+
+
+def test_info_has_no_prefix_naming_an_internal_function():
+    """`spells cards` used to announce itself as `add`, because the prefix came
+    from whichever helper happened to be running."""
+    import inspect
+
+    assert list(inspect.signature(console.info).parameters) == ["content"]


### PR DESCRIPTION
Phase 5 of `.claude/plans/spells-cli-file-management.md` — the last phase before the wizard.

## The bug this started from

I flagged this while writing the #33 walkthrough: piping `spells cards` printed the error *above* the line explaining what was being checked.

```
Card file for TST does not match the draft data.      <- stderr, unbuffered
  🪄 add ✨ Checking card file for TST against ...     <- stdout, block-buffered
```

Not a logic error — progress went to stdout via bare `print` while errors went to a rich console on stderr. Bare `print` is block-buffered when stdout is a pipe; rich flushes per call. Sharing one writer fixes the ordering:

```
  🪄 add ✨ Checking card file for TST against existing PremierDraft draft data
Card file for TST does not match the draft data.
  1 only in draft data: Gamma
  1 only in card file: Delta
```

## `--quiet`

```
spells --quiet <command>
```

Suppresses progress, leaves errors on stderr — headless rule 6. Verified: `spells --quiet clean TST` prints nothing and exits identically, while `spells --quiet cards TST` on a mismatch still reports and exits 1.

`NO_COLOR` and non-terminal detection come from rich rather than being reimplemented. Confirmed by inspecting the bytes: `\033[31m` on a forced terminal, gone under `NO_COLOR=1`.

## Where printing lives

`spells_print` lived in `cache`, which had no reason to own terminal output. It moves to `spells/console.py`, which imports nothing from spells so any module can use it without a cycle. Nothing outside the package referenced it — checked deq and deq-research — so no compatibility shim.

## The other four bare prints

Sorted by what they actually are, rather than all converted alike:

| site | was | now |
|---|---|---|
| `draft_data.py` non-serializable signature | `print` | `logging.warning` |
| `schema.py` unmatched column type | `print` | `logging.warning` |
| `extension.py` created-extension list | `print` | `console.detail` |
| `manifest.py` | `print(cdef)` then `assert False` | value folded into an `AssertionError` |

The first two are diagnostics for whoever is authoring a column — they belong in the log file (which already has a rotating handler) rather than in a user's output mid-download. This is **B3**'s second half from `spells-todo.md`; the message now says what to actually do, naming the `version` field and explaining that nothing will be reused across runs.

The `manifest.py` one printed a value immediately before `assert False` — a debugging leftover. The value belongs in the message, and it's a raise rather than a bare assert so `-O` can't strip it.

## Testing

**246 passing**, ruff clean. New `console_test.py` covers quiet suppression, errors never being suppressed, and stream separation — plus an ordering test that runs a real subprocess, because `capsys` doesn't reproduce the block buffering that caused the bug. Two CLI tests cover `--quiet` end to end, with an autouse fixture to stop the process-global flag leaking between tests.