### PR TITLE
Make a bare `spells` walk the user through it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # 🪄 spells ✨
 
+## Start here
+
+With the environment active, run:
+
+```
+$ spells
+```
+
+That walks you through downloading sets, updating them, and clearing out files
+that are no longer readable — and prints the equivalent command for whatever it
+does, so the individual verbs below are still there when you want them.
+
+---
+
 **spells** is a python package that tutors up blazing-fast and extensible analysis of the public data sets provided by [17Lands](https://www.17lands.com/) and exiles the annoying and slow parts of your workflow. Spells exposes one first-class function, `summon`, which summons a Polars DataFrame to the battlefield.
 
 ```

--- a/first_summon.py
+++ b/first_summon.py
@@ -12,9 +12,9 @@ from spells.enums import ColName, EventType
 def event_types_by_set(inv: inventory.Inventory) -> dict[str, list[EventType]]:
     """Each downloaded set, mapped to the event types it actually has.
 
-    `event_type` takes whichever shape suits the question. Leave it out
-    entirely for Premier draft alone, pass a list to ask every set for the same
-    ones, or pass a mapping like this one to give each set its own.
+    Passing one list instead would ask every set for every event type, and
+    asking for one a set does not have fails the read rather than returning
+    nothing for it.
     """
     return {
         set_inv.set_code: sorted(set_inv.events, key=str)

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:fe6310f6457838015ada16a013c1e07b44f00b379a6e49afbf96a7b08b795334"
+content_hash = "sha256:74743c7c62543bfadd650b959aaf75af783cb03b957dc6e44f1003179e6ca7fe"
 
 [[metadata.targets]]
 requires_python = ">=3.13"
@@ -1531,7 +1531,7 @@ name = "prompt-toolkit"
 version = "3.0.48"
 requires_python = ">=3.7.0"
 summary = "Library for building powerful interactive command lines in Python"
-groups = ["dev"]
+groups = ["default", "dev"]
 dependencies = [
     "wcwidth",
 ]
@@ -1783,6 +1783,20 @@ files = [
     {file = "pyzmq-26.2.0-cp313-cp313t-musllinux_1_1_i686.whl", hash = "sha256:007137c9ac9ad5ea21e6ad97d3489af654381324d5d3ba614c323f60dab8fae6"},
     {file = "pyzmq-26.2.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:470d4a4f6d48fb34e92d768b4e8a5cc3780db0d69107abf1cd7ff734b9766eb0"},
     {file = "pyzmq-26.2.0.tar.gz", hash = "sha256:070672c258581c8e4f640b5159297580a9974b026043bd4ab0470be9ed324f1f"},
+]
+
+[[package]]
+name = "questionary"
+version = "2.1.1"
+requires_python = ">=3.9"
+summary = "Python library to build pretty command line user prompts ⭐️"
+groups = ["default"]
+dependencies = [
+    "prompt-toolkit<4.0,>=2.0",
+]
+files = [
+    {file = "questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59"},
+    {file = "questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d"},
 ]
 
 [[package]]
@@ -2142,7 +2156,7 @@ files = [
 name = "wcwidth"
 version = "0.2.13"
 summary = "Measures the displayed width of unicode strings in a terminal"
-groups = ["dev"]
+groups = ["default", "dev"]
 dependencies = [
     "backports-functools-lru-cache>=1.2.1; python_version < \"3.2\"",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = [
 ]
 dependencies = [
     "polars==1.22.0",
+    "questionary>=2.1",
     "requests>=2.32",
     "typer>=0.27.0",
 ]

--- a/scripts/post_install.py
+++ b/scripts/post_install.py
@@ -3,14 +3,14 @@ import os
 import sys
 from pathlib import Path
 
-from spells.cache import spells_print
+from spells import console
 
 
 def modify_activation_script():
-    spells_print("install", "configuring environment for spells")
+    console.info("configuring environment for spells")
     venv_path = os.environ.get("VIRTUAL_ENV")
     if not venv_path:
-        print("No virtual environment found")
+        console.error("No virtual environment found")
         return
 
     if sys.platform == "win32":
@@ -19,7 +19,7 @@ def modify_activation_script():
         activate_script = Path(venv_path) / "bin" / "activate"
 
     if not activate_script.exists():
-        print(f"Activation script not found at {activate_script}")
+        console.error(f"Activation script not found at {activate_script}")
         return
 
     with open(activate_script, "a") as f:

--- a/spells/cli.py
+++ b/spells/cli.py
@@ -5,37 +5,25 @@ import sys
 from typing import Annotated
 
 import typer
-from rich.console import Console
 from rich.padding import Padding
 from rich.table import Table
 
-from spells import cache, cards as cards_module, catalog, external, inventory
+from spells import cache, cards as cards_module, catalog, external, inventory, render
 from spells import console as spells_console
 from spells.console import sizeof_fmt
+from spells.render import console, err_console
 from spells.cache import DataDir
-from spells.catalog import Freshness, Target
+from spells.catalog import Target
 from spells import repair
-from spells.enums import EventType, View
-from spells.inventory import Anomaly, AnomalyKind, Inventory
+from spells.enums import EventType
+from spells.inventory import Anomaly, Inventory
 
-ANOMALY_HELP = {
-    AnomalyKind.STRAY_DOWNLOAD: "leftover download artifacts",
-    AnomalyKind.LEGACY_CONTEXT: "pre-event_type context files",
-    AnomalyKind.LEGACY_SNAPSHOT: "pre-0.14 snapshots, unreadable today",
-    AnomalyKind.ORPHAN_CACHE: "cache with no data to rebuild from",
-    AnomalyKind.ORPHAN_DIR: "directories spells does not write",
-    AnomalyKind.UNKNOWN_FILE: "unrecognized files",
-    AnomalyKind.INCOMPLETE_SET: "sets missing dataset files",
-}
 
 app = typer.Typer(
     help="Manage 17Lands public datasets, card files, and local caches.",
     no_args_is_help=False,
     context_settings={"help_option_names": ["-h", "--help"]},
 )
-
-console = Console()
-err_console = Console(stderr=True)
 
 
 def _confirm(action: str, yes: bool) -> None:
@@ -138,106 +126,6 @@ def _inventory_dict(inv: Inventory, sets: list) -> dict:
     }
 
 
-def _event_summary(set_inv) -> str:
-    if not set_inv.events:
-        return "[dim]—[/dim]"
-    parts = []
-    for event, files in set_inv.events.items():
-        if files.is_complete:
-            parts.append(str(event))
-        else:
-            parts.append(f"[yellow]{event} (no {', '.join(files.missing)})[/yellow]")
-    return "\n".join(parts)
-
-
-def _snapshot_summary(set_inv) -> str:
-    valid = set_inv.ratings.valid + set_inv.deck_color.valid
-    legacy = set_inv.ratings.legacy + set_inv.deck_color.legacy
-    if not valid and not legacy:
-        return "[dim]—[/dim]"
-    text = f"{valid}"
-    if legacy:
-        text += f" [yellow]+{legacy} old[/yellow]"
-    return text
-
-
-def _render_status(
-    inv: Inventory, sets: list, anomalies: list[Anomaly], detailed: bool
-) -> None:
-    console.print(
-        f"  🪄 [bold]spells[/bold] ✨ {inv.data_home} "
-        f"[dim]({sizeof_fmt(inv.total_bytes)})[/dim]\n"
-    )
-
-    if not sets:
-        console.print("  [dim]No data found. Try `spells add DSK`.[/dim]")
-        return
-
-    table = Table(box=None, pad_edge=False, header_style="bold")
-    table.add_column("set")
-    table.add_column("external", justify="right")
-    table.add_column("cards", justify="center")
-    table.add_column("cache", justify="right")
-    table.add_column("snapshots", justify="right")
-    table.add_column("event types")
-
-    for s in sets:
-        table.add_row(
-            s.set_code,
-            sizeof_fmt(s.external_bytes) if s.external_bytes else "[dim]—[/dim]",
-            "✓" if s.card_file else "[dim]—[/dim]",
-            str(s.cache_files) if s.cache_files else "[dim]—[/dim]",
-            _snapshot_summary(s),
-            _event_summary(s),
-        )
-
-    console.print(Padding(table, (0, 0, 0, 2)))
-
-    # cached draft logs are keyed by draft id alone, so they cannot be
-    # attributed to the set being reported on
-    if inv.draft_logs and not detailed:
-        console.print(
-            f"\n  {inv.draft_logs} cached draft logs "
-            f"[dim]({sizeof_fmt(inv.draft_log_bytes)})[/dim]"
-        )
-
-    if not anomalies:
-        return
-
-    console.print(f"\n[bold]issues[/bold] ({len(anomalies)})")
-
-    if detailed:
-        for a in anomalies:
-            size = f" [dim]{sizeof_fmt(a.size)}[/dim]" if a.size else ""
-            # soft_wrap keeps long paths on one line for copy-paste
-            console.print(
-                f"  [yellow]{a.kind}[/yellow]{size} — {a.detail}", soft_wrap=True
-            )
-            console.print(f"    [dim]{a.path}[/dim]", soft_wrap=True)
-        return
-
-    summary = Table(box=None, pad_edge=False, show_header=False)
-    summary.add_column(style="yellow")
-    summary.add_column(justify="right")
-    summary.add_column(justify="right")
-    summary.add_column(style="dim")
-
-    for kind in AnomalyKind:
-        matching = [a for a in anomalies if a.kind == kind]
-        if not matching:
-            continue
-        size = sum(a.size for a in matching)
-        summary.add_row(
-            str(kind),
-            str(len(matching)),
-            sizeof_fmt(size) if size else "—",
-            ANOMALY_HELP[kind],
-        )
-
-    console.print(Padding(summary, (0, 0, 0, 2)))
-    console.print("\n  [dim]`spells status <SET>` for detail[/dim]")
-
-
 @app.callback(invoke_without_command=True)
 def main(
     ctx: typer.Context,
@@ -289,7 +177,7 @@ def status(
         print(json.dumps(_inventory_dict(inv, sets), indent=2))
         return
 
-    _render_status(inv, sets, anomalies, detailed=set_code is not None)
+    render._render_status(inv, sets, anomalies, detailed=set_code is not None)
 
 
 @app.command(hidden=True)
@@ -362,19 +250,6 @@ def clean(
     raise typer.Exit(cache.clean(set_code))
 
 
-FRESHNESS_STYLE = {
-    Freshness.CURRENT: ("[green]current[/green]", "up to date"),
-    Freshness.STALE: ("[yellow]stale[/yellow]", "17Lands has newer data"),
-    Freshness.ABSENT: ("[cyan]absent[/cyan]", "published, not downloaded"),
-    Freshness.UNPUBLISHED: ("[dim]unpublished[/dim]", "17Lands does not publish it"),
-    Freshness.UNKNOWN: ("[dim]unknown[/dim]", "could not determine"),
-}
-
-CHECKED_VIEWS = (View.DRAFT, View.GAME)
-
-UNADDED_SHOWN = 5
-
-
 def _targets(
     inv: Inventory, set_code: str | None, cat: catalog.Catalog
 ) -> list[Target]:
@@ -400,116 +275,12 @@ def _targets(
         held = set(set_inv.events) if set_inv else set()
         for event_type in sorted(published | held):
             files = set_inv.events.get(event_type) if set_inv else None
-            for view in CHECKED_VIEWS:
+            for view in render.CHECKED_VIEWS:
                 local = getattr(files, view, None) if files else None
                 targets.append(
                     Target(expansion, event_type, view, local.mtime if local else None)
                 )
     return targets
-
-
-def _held_events(inv: Inventory) -> set[tuple[str, EventType]]:
-    return {(s.set_code, event) for s in inv.sets.values() for event in s.events}
-
-
-def _is_actionable(row: catalog.CheckRow, held: set[tuple[str, EventType]]) -> bool:
-    """Whether a row represents something the user actually needs to do.
-
-    An event type they have never added is a suggestion, not a defect: nearly
-    every set publishes TradDraft, so counting those as work would make the
-    exit-3 contract fire permanently and be useless to cron.
-    """
-    if row.freshness == Freshness.STALE:
-        return True
-    key = (row.target.expansion, row.target.event_type)
-    return row.freshness == Freshness.ABSENT and key in held
-
-
-def _render_check(
-    rows: list[catalog.CheckRow],
-    cat: catalog.Catalog,
-    held: set[tuple[str, EventType]],
-    detailed: bool,
-    unadded: list[str],
-) -> None:
-    if cat.is_fallback:
-        err_console.print(
-            "[yellow]Could not reach the 17Lands catalog; "
-            "reporting local state only.[/yellow]\n"
-        )
-
-    if not rows:
-        console.print("  [dim]Nothing to check. Try `spells add DSK`.[/dim]")
-        return
-
-    tracked = [r for r in rows if (r.target.expansion, r.target.event_type) in held]
-    untracked = [r for r in rows if r not in tracked]
-
-    if tracked:
-        table = Table(box=None, pad_edge=False, header_style="bold")
-        table.add_column("set")
-        table.add_column("event type")
-        table.add_column("file")
-        table.add_column("status")
-        table.add_column("updated", justify="right")
-
-        for row in tracked:
-            remote = row.remote
-            when = "[dim]—[/dim]"
-            if remote is not None and remote.last_modified is not None:
-                when = remote.last_modified.date().isoformat()
-            table.add_row(
-                row.target.expansion,
-                str(row.target.event_type),
-                str(row.target.view),
-                FRESHNESS_STYLE[row.freshness][0],
-                when,
-            )
-
-        console.print(Padding(table, (0, 0, 0, 2)))
-
-    if untracked:
-        available: dict[str, set[EventType]] = {}
-        for row in untracked:
-            if row.freshness == Freshness.ABSENT:
-                available.setdefault(row.target.expansion, set()).add(
-                    row.target.event_type
-                )
-
-        if available and detailed:
-            console.print("\n  [bold]also published[/bold] [dim](not added)[/dim]")
-            for expansion, events in sorted(available.items()):
-                names = ", ".join(sorted(str(e) for e in events))
-                console.print(f"    {expansion}: [cyan]{names}[/cyan]")
-        elif available:
-            events = sorted({str(e) for evs in available.values() for e in evs})
-            console.print(
-                f"\n  [dim]{len(available)} set(s) also publish "
-                f"{', '.join(events)}[/dim]"
-            )
-            console.print("  [dim]`spells check <SET>` for detail[/dim]")
-
-    if unadded:
-        shown = unadded[:UNADDED_SHOWN]
-        console.print(f"\n  [bold]published, not added[/bold] ({len(unadded)})")
-        for expansion in shown:
-            when = cat.updated(expansion)
-            console.print(
-                f"    [cyan]{expansion:<14}[/cyan] "
-                f"[dim]{when.isoformat() if when else '—'}[/dim]"
-            )
-        if len(unadded) > len(shown):
-            console.print(f"    [dim]+{len(unadded) - len(shown)} older[/dim]")
-
-    work = sorted({r.target.expansion for r in tracked if _is_actionable(r, held)})
-    if work:
-        console.print(
-            f"\n  [bold]{len(work)} set(s) incomplete or out of date:[/bold] "
-            f"{', '.join(work)}"
-        )
-        console.print(
-            "  [dim]`spells add <SET>` fills gaps, `refresh` re-downloads[/dim]"
-        )
 
 
 @app.command()
@@ -530,7 +301,7 @@ def check(
     inv = inventory.scan()
     cat = catalog.fetch()
     rows = catalog.resolve(_targets(inv, set_code, cat), cat)
-    held = _held_events(inv)
+    held = render._held_events(inv)
 
     # only meaningful for the whole-data-home view; naming a set already says
     # which expansion you care about
@@ -570,7 +341,7 @@ def check(
                             "status": str(r.freshness),
                             "tracked": (r.target.expansion, r.target.event_type)
                             in held,
-                            "actionable": _is_actionable(r, held),
+                            "actionable": render._is_actionable(r, held),
                             "url": r.remote.url if r.remote else None,
                             "remote_last_modified": (
                                 r.remote.last_modified.isoformat()
@@ -586,9 +357,11 @@ def check(
             )
         )
     else:
-        _render_check(rows, cat, held, detailed=set_code is not None, unadded=unadded)
+        render._render_check(
+            rows, cat, held, detailed=set_code is not None, unadded=unadded
+        )
 
-    if any(_is_actionable(r, held) for r in rows):
+    if any(render._is_actionable(r, held) for r in rows):
         raise typer.Exit(3)
 
 
@@ -629,46 +402,6 @@ def path(
         target = cache.data_dir_path(kind)
 
     print(target)
-
-
-def _render_repairs(repairs: list[repair.Repair]) -> None:
-    total_files = sum(r.files for r in repairs)
-    total_size = sum(r.size for r in repairs)
-
-    table = Table(box=None, pad_edge=False, header_style="bold")
-    table.add_column("issue")
-    table.add_column("set")
-    table.add_column("files", justify="right")
-    table.add_column("size", justify="right")
-
-    for r in repairs:
-        table.add_row(
-            str(r.anomaly.kind),
-            r.anomaly.set_code or "[dim]—[/dim]",
-            str(r.files),
-            sizeof_fmt(r.size),
-        )
-
-    console.print(Padding(table, (0, 0, 0, 2)))
-    console.print(
-        f"\n  [bold]would remove {total_files} file(s)[/bold], "
-        f"{sizeof_fmt(total_size)}"
-    )
-
-
-def _render_advisories(inv: Inventory, set_code: str | None) -> None:
-    advisories = [
-        a
-        for a in inv.all_anomalies
-        if not a.is_repairable and (set_code is None or a.set_code == set_code)
-    ]
-    if not advisories:
-        return
-
-    console.print(f"\n  [bold]needs your judgement[/bold] ({len(advisories)})")
-    for a in advisories:
-        console.print(f"    [yellow]{a.kind}[/yellow] {a.detail}", soft_wrap=True)
-        console.print(f"      [dim]{a.path}[/dim]", soft_wrap=True)
 
 
 def _repair_dict(r: repair.Repair) -> dict:
@@ -739,12 +472,12 @@ def doctor(
 
     if not repairs:
         console.print("  [green]Nothing to repair.[/green]")
-        _render_advisories(inv, set_code)
+        render._render_advisories(inv, set_code)
         return
 
-    _render_repairs(repairs)
+    render._render_repairs(repairs)
     _run_repairs(repairs, yes, "delete them")
-    _render_advisories(inv, set_code)
+    render._render_advisories(inv, set_code)
 
 
 @app.command()

--- a/spells/cli.py
+++ b/spells/cli.py
@@ -11,6 +11,7 @@ from rich.table import Table
 
 from spells import cache, cards as cards_module, catalog, external, inventory
 from spells import console as spells_console
+from spells.console import sizeof_fmt
 from spells.cache import DataDir
 from spells.catalog import Freshness, Target
 from spells import repair
@@ -35,15 +36,6 @@ app = typer.Typer(
 
 console = Console()
 err_console = Console(stderr=True)
-
-
-# Fred Cirera via https://stackoverflow.com/questions/1094841/get-a-human-readable-version-of-a-file-size
-def sizeof_fmt(num: float, suffix: str = "B") -> str:
-    for unit in ("", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"):
-        if abs(num) < 1024.0:
-            return f"{num:3.1f}{unit}{suffix}"
-        num /= 1024.0
-    return f"{num:.1f}Yi{suffix}"
 
 
 def _confirm(action: str, yes: bool) -> None:
@@ -255,7 +247,16 @@ def main(
     ] = False,
 ) -> None:
     spells_console.set_quiet(quiet)
-    if ctx.invoked_subcommand is None:
+    if ctx.invoked_subcommand is not None:
+        return
+
+    # the walkthrough needs a terminal to prompt into; anything else — a pipe,
+    # cron, `spells | less` — gets the report it would have got before
+    if _is_interactive() and not quiet:
+        from spells import wizard
+
+        wizard.run()
+    else:
         status()
 
 

--- a/spells/console.py
+++ b/spells/console.py
@@ -47,3 +47,12 @@ def detail(content: str) -> None:
 def error(content: str) -> None:
     """Failures, on stderr and never suppressed."""
     _err.print(f"[red]{content}[/red]", soft_wrap=True)
+
+
+# Fred Cirera via https://stackoverflow.com/questions/1094841/get-a-human-readable-version-of-a-file-size
+def sizeof_fmt(num: float, suffix: str = "B") -> str:
+    for unit in ("", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"):
+        if abs(num) < 1024.0:
+            return f"{num:3.1f}{unit}{suffix}"
+        num /= 1024.0
+    return f"{num:.1f}Yi{suffix}"

--- a/spells/examples/first_summon.py
+++ b/spells/examples/first_summon.py
@@ -5,36 +5,47 @@ Run it with `python first_summon.py`, then change something and run it again.
 across; every name comes from `spells.enums.ColName`.
 """
 
+from collections import defaultdict
+
+import polars as pl
+
 from spells import inventory, summon
-from spells.enums import ColName
+from spells.enums import ColName, EventType
 
 
-def installed() -> tuple[list[str], list[str]]:
-    """Only what is downloaded.
+def by_event_types(inv: inventory.Inventory) -> dict[tuple[EventType, ...], list[str]]:
+    """Downloaded sets, grouped by exactly which event types they have.
 
-    Naming an event type with no parquet on disk fails the read rather than
-    returning nothing for it, so the query is built from the inventory instead
-    of from everything 17Lands publishes.
+    `summon` takes the product of the sets and the event types it is given, so
+    a single call naming every event type fails the read for any set missing
+    one rather than skipping it. Grouping first means each call asks only for
+    cells that exist — one call per distinct combination instead of one per
+    set.
     """
-    inv = inventory.scan()
-    sets = sorted(s.set_code for s in inv.sets.values() if s.has_external)
-    event_types = sorted({e for s in inv.sets.values() for e in s.events}, key=str)
-    return sets, event_types
+    groups = defaultdict(list)
+    for set_inv in inv.sets.values():
+        if set_inv.has_external:
+            groups[tuple(sorted(set_inv.events, key=str))].append(set_inv.set_code)
+    return dict(groups)
 
 
 def main() -> None:
-    sets, event_types = installed()
-    if not sets:
+    groups = by_event_types(inventory.scan())
+    if not groups:
         print("No sets downloaded yet. Run `spells` to get some.")
         return
 
-    df = summon(
-        sets,
-        columns=[ColName.NUM_TAKEN, ColName.NUM_GAMES],
-        group_by=[ColName.EXPANSION, ColName.EVENT_TYPE],
-        event_type=event_types,
-    )
-    print(df)
+    frames = [
+        summon(
+            sorted(set_codes),
+            columns=[ColName.NUM_TAKEN, ColName.NUM_GAMES],
+            group_by=[ColName.EXPANSION, ColName.EVENT_TYPE],
+            event_type=list(event_types),
+        )
+        for event_types, set_codes in groups.items()
+    ]
+
+    print(pl.concat(frames).sort([ColName.EXPANSION, ColName.EVENT_TYPE]))
 
 
 if __name__ == "__main__":

--- a/spells/examples/first_summon.py
+++ b/spells/examples/first_summon.py
@@ -1,0 +1,41 @@
+"""What spells knows about the data you have.
+
+Run it with `python first_summon.py`, then change something and run it again.
+`columns` are what you want measured, `group_by` is what you want them measured
+across; every name comes from `spells.enums.ColName`.
+"""
+
+from spells import inventory, summon
+from spells.enums import ColName
+
+
+def installed() -> tuple[list[str], list[str]]:
+    """Only what is downloaded.
+
+    Naming an event type with no parquet on disk fails the read rather than
+    returning nothing for it, so the query is built from the inventory instead
+    of from everything 17Lands publishes.
+    """
+    inv = inventory.scan()
+    sets = sorted(s.set_code for s in inv.sets.values() if s.has_external)
+    event_types = sorted({e for s in inv.sets.values() for e in s.events}, key=str)
+    return sets, event_types
+
+
+def main() -> None:
+    sets, event_types = installed()
+    if not sets:
+        print("No sets downloaded yet. Run `spells` to get some.")
+        return
+
+    df = summon(
+        sets,
+        columns=[ColName.NUM_TAKEN, ColName.NUM_GAMES],
+        group_by=[ColName.EXPANSION, ColName.EVENT_TYPE],
+        event_type=event_types,
+    )
+    print(df)
+
+
+if __name__ == "__main__":
+    main()

--- a/spells/examples/first_summon.py
+++ b/spells/examples/first_summon.py
@@ -5,47 +5,37 @@ Run it with `python first_summon.py`, then change something and run it again.
 across; every name comes from `spells.enums.ColName`.
 """
 
-from collections import defaultdict
-
-import polars as pl
-
 from spells import inventory, summon
 from spells.enums import ColName, EventType
 
 
-def by_event_types(inv: inventory.Inventory) -> dict[tuple[EventType, ...], list[str]]:
-    """Downloaded sets, grouped by exactly which event types they have.
+def event_types_by_set(inv: inventory.Inventory) -> dict[str, list[EventType]]:
+    """Each downloaded set, mapped to the event types it actually has.
 
-    `summon` takes the product of the sets and the event types it is given, so
-    a single call naming every event type fails the read for any set missing
-    one rather than skipping it. Grouping first means each call asks only for
-    cells that exist — one call per distinct combination instead of one per
-    set.
+    Passing one list instead would ask every set for every event type, and
+    asking for one a set does not have fails the read rather than returning
+    nothing for it.
     """
-    groups = defaultdict(list)
-    for set_inv in inv.sets.values():
-        if set_inv.has_external:
-            groups[tuple(sorted(set_inv.events, key=str))].append(set_inv.set_code)
-    return dict(groups)
+    return {
+        set_inv.set_code: sorted(set_inv.events, key=str)
+        for set_inv in inv.sets.values()
+        if set_inv.has_external
+    }
 
 
 def main() -> None:
-    groups = by_event_types(inventory.scan())
-    if not groups:
+    by_set = event_types_by_set(inventory.scan())
+    if not by_set:
         print("No sets downloaded yet. Run `spells` to get some.")
         return
 
-    frames = [
-        summon(
-            sorted(set_codes),
-            columns=[ColName.NUM_TAKEN, ColName.NUM_GAMES],
-            group_by=[ColName.EXPANSION, ColName.EVENT_TYPE],
-            event_type=list(event_types),
-        )
-        for event_types, set_codes in groups.items()
-    ]
-
-    print(pl.concat(frames).sort([ColName.EXPANSION, ColName.EVENT_TYPE]))
+    df = summon(
+        sorted(by_set),
+        columns=[ColName.NUM_TAKEN, ColName.NUM_GAMES],
+        group_by=[ColName.EXPANSION, ColName.EVENT_TYPE],
+        event_type=by_set,
+    )
+    print(df.sort([ColName.EXPANSION, ColName.EVENT_TYPE]))
 
 
 if __name__ == "__main__":

--- a/spells/external.py
+++ b/spells/external.py
@@ -113,6 +113,42 @@ def _remove(set_code: str):
     return cache.clean(set_code)
 
 
+def _remove_event_type(set_code: str, event_type: EventType) -> int:
+    """Delete one event type's datasets, leaving the rest of the set.
+
+    The card file describes the whole set, so it only goes when the last event
+    type does — a card file with no draft data beside it is not something the
+    scanner would call a set, and nothing can rebuild from it.
+    """
+    dir_path = cache.external_set_path(set_code)
+    if not os.path.isdir(dir_path):
+        console.info(f"No external cache found for set {set_code}")
+        return 1
+
+    prefix = f"{set_code}_{event_type}_"
+    removed = 0
+    with os.scandir(dir_path) as entries:
+        for entry in entries:
+            if entry.name.startswith(prefix):
+                os.remove(entry.path)
+                removed += 1
+
+    if not removed:
+        console.info(f"No {event_type} data found for set {set_code}")
+        return 1
+
+    console.info(f"Removed {removed} {event_type} files for set {set_code}")
+
+    leftovers = [e.name for e in os.scandir(dir_path)]
+    if all(name == f"{set_code}_card.parquet" for name in leftovers):
+        for name in leftovers:
+            os.remove(os.path.join(dir_path, name))
+        os.rmdir(dir_path)
+        console.info(f"Removed {set_code}; no event types left")
+
+    return cache.clean(set_code)
+
+
 def _process_zipped_file(gzip_path, target_path):
     csv_path = gzip_path[:-3]
     # if polars supports streaming from file obj, we can just stream straight

--- a/spells/render.py
+++ b/spells/render.py
@@ -81,23 +81,30 @@ def _render_status(
         console.print("  [dim]No data found. Try `spells add DSK`.[/dim]")
         return
 
+    # snapshots only exist for callers of the private ratings API, so for most
+    # users the column would be a header over a column of dashes
+    show_snapshots = any(s.ratings.total or s.deck_color.total for s in sets)
+
     table = Table(box=None, pad_edge=False, header_style="bold")
     table.add_column("set")
     table.add_column("external", justify="right")
     table.add_column("cards", justify="center")
     table.add_column("cache", justify="right")
-    table.add_column("snapshots", justify="right")
+    if show_snapshots:
+        table.add_column("snapshots", justify="right")
     table.add_column("event types")
 
     for s in sets:
-        table.add_row(
+        row = [
             s.set_code,
             sizeof_fmt(s.external_bytes) if s.external_bytes else "[dim]—[/dim]",
             "✓" if s.card_file else "[dim]—[/dim]",
             str(s.cache_files) if s.cache_files else "[dim]—[/dim]",
-            _snapshot_summary(s),
-            _event_summary(s),
-        )
+        ]
+        if show_snapshots:
+            row.append(_snapshot_summary(s))
+        row.append(_event_summary(s))
+        table.add_row(*row)
 
     console.print(Padding(table, (0, 0, 0, 2)))
 

--- a/spells/render.py
+++ b/spells/render.py
@@ -101,11 +101,19 @@ def _render_status(
 
     console.print(Padding(table, (0, 0, 0, 2)))
 
+    cache_files = sum(s.cache_files for s in sets)
+    if cache_files:
+        cache_bytes = sum(s.cache_bytes for s in sets)
+        console.print(
+            f"\n  {cache_files} cached query results "
+            f"[dim]({sizeof_fmt(cache_bytes)}, rebuild on demand)[/dim]"
+        )
+
     # cached draft logs are keyed by draft id alone, so they cannot be
     # attributed to the set being reported on
     if inv.draft_logs and not detailed:
         console.print(
-            f"\n  {inv.draft_logs} cached draft logs "
+            f"  {inv.draft_logs} cached draft logs "
             f"[dim]({sizeof_fmt(inv.draft_log_bytes)})[/dim]"
         )
 

--- a/spells/render.py
+++ b/spells/render.py
@@ -1,0 +1,303 @@
+"""Rendering the inventory, the catalog comparison, and planned repairs.
+
+The flat commands and the walkthrough show the same things, so the tables live
+here rather than in either of them — `cli` would otherwise have to import
+`wizard` and be imported back.
+
+Nothing here decides anything. Deciding what is stale, what is repairable, and
+what a set even is belongs to `inventory`, `catalog`, and `repair`.
+"""
+
+from rich.console import Console
+from rich.padding import Padding
+from rich.table import Table
+
+from spells import catalog, repair
+from spells.catalog import Freshness
+from spells.console import sizeof_fmt
+from spells.enums import EventType, View
+from spells.inventory import Anomaly, AnomalyKind, Inventory
+
+console = Console()
+err_console = Console(stderr=True)
+
+BANNER = r"""[bold magenta]                _ _
+ ___ _ __   ___| | |___
+/ __| '_ \ / _ \ | / __|
+\__ \ |_) |  __/ | \__ \
+|___/ .__/ \___|_|_|___/
+    |_|[/bold magenta]"""
+
+
+def banner() -> None:
+    """Art only. Where the data lives is the status header's job, and the
+    walkthrough prints that immediately after."""
+    console.print(BANNER)
+
+
+ANOMALY_HELP = {
+    AnomalyKind.STRAY_DOWNLOAD: "leftover download artifacts",
+    AnomalyKind.LEGACY_CONTEXT: "pre-event_type context files",
+    AnomalyKind.LEGACY_SNAPSHOT: "pre-0.14 snapshots, unreadable today",
+    AnomalyKind.ORPHAN_CACHE: "cache with no data to rebuild from",
+    AnomalyKind.ORPHAN_DIR: "directories spells does not write",
+    AnomalyKind.UNKNOWN_FILE: "unrecognized files",
+    AnomalyKind.INCOMPLETE_SET: "sets missing dataset files",
+}
+
+
+def _event_summary(set_inv) -> str:
+    if not set_inv.events:
+        return "[dim]—[/dim]"
+    parts = []
+    for event, files in set_inv.events.items():
+        if files.is_complete:
+            parts.append(str(event))
+        else:
+            parts.append(f"[yellow]{event} (no {', '.join(files.missing)})[/yellow]")
+    return "\n".join(parts)
+
+
+def _snapshot_summary(set_inv) -> str:
+    valid = set_inv.ratings.valid + set_inv.deck_color.valid
+    legacy = set_inv.ratings.legacy + set_inv.deck_color.legacy
+    if not valid and not legacy:
+        return "[dim]—[/dim]"
+    text = f"{valid}"
+    if legacy:
+        text += f" [yellow]+{legacy} old[/yellow]"
+    return text
+
+
+def _render_status(
+    inv: Inventory, sets: list, anomalies: list[Anomaly], detailed: bool
+) -> None:
+    console.print(
+        f"  🪄 [bold]spells[/bold] ✨ {inv.data_home} "
+        f"[dim]({sizeof_fmt(inv.total_bytes)})[/dim]\n"
+    )
+
+    if not sets:
+        console.print("  [dim]No data found. Try `spells add DSK`.[/dim]")
+        return
+
+    table = Table(box=None, pad_edge=False, header_style="bold")
+    table.add_column("set")
+    table.add_column("external", justify="right")
+    table.add_column("cards", justify="center")
+    table.add_column("cache", justify="right")
+    table.add_column("snapshots", justify="right")
+    table.add_column("event types")
+
+    for s in sets:
+        table.add_row(
+            s.set_code,
+            sizeof_fmt(s.external_bytes) if s.external_bytes else "[dim]—[/dim]",
+            "✓" if s.card_file else "[dim]—[/dim]",
+            str(s.cache_files) if s.cache_files else "[dim]—[/dim]",
+            _snapshot_summary(s),
+            _event_summary(s),
+        )
+
+    console.print(Padding(table, (0, 0, 0, 2)))
+
+    # cached draft logs are keyed by draft id alone, so they cannot be
+    # attributed to the set being reported on
+    if inv.draft_logs and not detailed:
+        console.print(
+            f"\n  {inv.draft_logs} cached draft logs "
+            f"[dim]({sizeof_fmt(inv.draft_log_bytes)})[/dim]"
+        )
+
+    if not anomalies:
+        return
+
+    console.print(f"\n[bold]issues[/bold] ({len(anomalies)})")
+
+    if detailed:
+        for a in anomalies:
+            size = f" [dim]{sizeof_fmt(a.size)}[/dim]" if a.size else ""
+            # soft_wrap keeps long paths on one line for copy-paste
+            console.print(
+                f"  [yellow]{a.kind}[/yellow]{size} — {a.detail}", soft_wrap=True
+            )
+            console.print(f"    [dim]{a.path}[/dim]", soft_wrap=True)
+        return
+
+    summary = Table(box=None, pad_edge=False, show_header=False)
+    summary.add_column(style="yellow")
+    summary.add_column(justify="right")
+    summary.add_column(justify="right")
+    summary.add_column(style="dim")
+
+    for kind in AnomalyKind:
+        matching = [a for a in anomalies if a.kind == kind]
+        if not matching:
+            continue
+        size = sum(a.size for a in matching)
+        summary.add_row(
+            str(kind),
+            str(len(matching)),
+            sizeof_fmt(size) if size else "—",
+            ANOMALY_HELP[kind],
+        )
+
+    console.print(Padding(summary, (0, 0, 0, 2)))
+    console.print("\n  [dim]`spells status <SET>` for detail[/dim]")
+
+
+FRESHNESS_STYLE = {
+    Freshness.CURRENT: ("[green]current[/green]", "up to date"),
+    Freshness.STALE: ("[yellow]stale[/yellow]", "17Lands has newer data"),
+    Freshness.ABSENT: ("[cyan]absent[/cyan]", "published, not downloaded"),
+    Freshness.UNPUBLISHED: ("[dim]unpublished[/dim]", "17Lands does not publish it"),
+    Freshness.UNKNOWN: ("[dim]unknown[/dim]", "could not determine"),
+}
+
+CHECKED_VIEWS = (View.DRAFT, View.GAME)
+
+UNADDED_SHOWN = 5
+
+
+def _held_events(inv: Inventory) -> set[tuple[str, EventType]]:
+    return {(s.set_code, event) for s in inv.sets.values() for event in s.events}
+
+
+def _is_actionable(row: catalog.CheckRow, held: set[tuple[str, EventType]]) -> bool:
+    """Whether a row represents something the user actually needs to do.
+
+    An event type they have never added is a suggestion, not a defect: nearly
+    every set publishes TradDraft, so counting those as work would make the
+    exit-3 contract fire permanently and be useless to cron.
+    """
+    if row.freshness == Freshness.STALE:
+        return True
+    key = (row.target.expansion, row.target.event_type)
+    return row.freshness == Freshness.ABSENT and key in held
+
+
+def _render_check(
+    rows: list[catalog.CheckRow],
+    cat: catalog.Catalog,
+    held: set[tuple[str, EventType]],
+    detailed: bool,
+    unadded: list[str],
+) -> None:
+    if cat.is_fallback:
+        err_console.print(
+            "[yellow]Could not reach the 17Lands catalog; "
+            "reporting local state only.[/yellow]\n"
+        )
+
+    if not rows:
+        console.print("  [dim]Nothing to check. Try `spells add DSK`.[/dim]")
+        return
+
+    tracked = [r for r in rows if (r.target.expansion, r.target.event_type) in held]
+    untracked = [r for r in rows if r not in tracked]
+
+    if tracked:
+        table = Table(box=None, pad_edge=False, header_style="bold")
+        table.add_column("set")
+        table.add_column("event type")
+        table.add_column("file")
+        table.add_column("status")
+        table.add_column("updated", justify="right")
+
+        for row in tracked:
+            remote = row.remote
+            when = "[dim]—[/dim]"
+            if remote is not None and remote.last_modified is not None:
+                when = remote.last_modified.date().isoformat()
+            table.add_row(
+                row.target.expansion,
+                str(row.target.event_type),
+                str(row.target.view),
+                FRESHNESS_STYLE[row.freshness][0],
+                when,
+            )
+
+        console.print(Padding(table, (0, 0, 0, 2)))
+
+    if untracked:
+        available: dict[str, set[EventType]] = {}
+        for row in untracked:
+            if row.freshness == Freshness.ABSENT:
+                available.setdefault(row.target.expansion, set()).add(
+                    row.target.event_type
+                )
+
+        if available and detailed:
+            console.print("\n  [bold]also published[/bold] [dim](not added)[/dim]")
+            for expansion, events in sorted(available.items()):
+                names = ", ".join(sorted(str(e) for e in events))
+                console.print(f"    {expansion}: [cyan]{names}[/cyan]")
+        elif available:
+            events = sorted({str(e) for evs in available.values() for e in evs})
+            console.print(
+                f"\n  [dim]{len(available)} set(s) also publish "
+                f"{', '.join(events)}[/dim]"
+            )
+            console.print("  [dim]`spells check <SET>` for detail[/dim]")
+
+    if unadded:
+        shown = unadded[:UNADDED_SHOWN]
+        console.print(f"\n  [bold]published, not added[/bold] ({len(unadded)})")
+        for expansion in shown:
+            when = cat.updated(expansion)
+            console.print(
+                f"    [cyan]{expansion:<14}[/cyan] "
+                f"[dim]{when.isoformat() if when else '—'}[/dim]"
+            )
+        if len(unadded) > len(shown):
+            console.print(f"    [dim]+{len(unadded) - len(shown)} older[/dim]")
+
+    work = sorted({r.target.expansion for r in tracked if _is_actionable(r, held)})
+    if work:
+        console.print(
+            f"\n  [bold]{len(work)} set(s) incomplete or out of date:[/bold] "
+            f"{', '.join(work)}"
+        )
+        console.print(
+            "  [dim]`spells add <SET>` fills gaps, `refresh` re-downloads[/dim]"
+        )
+
+
+def _render_repairs(repairs: list[repair.Repair]) -> None:
+    total_files = sum(r.files for r in repairs)
+    total_size = sum(r.size for r in repairs)
+
+    table = Table(box=None, pad_edge=False, header_style="bold")
+    table.add_column("issue")
+    table.add_column("set")
+    table.add_column("files", justify="right")
+    table.add_column("size", justify="right")
+
+    for r in repairs:
+        table.add_row(
+            str(r.anomaly.kind),
+            r.anomaly.set_code or "[dim]—[/dim]",
+            str(r.files),
+            sizeof_fmt(r.size),
+        )
+
+    console.print(Padding(table, (0, 0, 0, 2)))
+    console.print(
+        f"\n  [bold]would remove {total_files} file(s)[/bold], "
+        f"{sizeof_fmt(total_size)}"
+    )
+
+
+def _render_advisories(inv: Inventory, set_code: str | None) -> None:
+    advisories = [
+        a
+        for a in inv.all_anomalies
+        if not a.is_repairable and (set_code is None or a.set_code == set_code)
+    ]
+    if not advisories:
+        return
+
+    console.print(f"\n  [bold]needs your judgement[/bold] ({len(advisories)})")
+    for a in advisories:
+        console.print(f"    [yellow]{a.kind}[/yellow] {a.detail}", soft_wrap=True)
+        console.print(f"      [dim]{a.path}[/dim]", soft_wrap=True)

--- a/spells/wizard.py
+++ b/spells/wizard.py
@@ -495,15 +495,6 @@ def clear_cache(
     cache.clean("all")
 
 
-HANDLERS = {
-    "download": download,
-    "remove": remove,
-    "summon": try_summon,
-    "repair": free_space,
-    "cache": clear_cache,
-}
-
-
 # ---------------------------------------------------------------------------
 # Flow
 # ---------------------------------------------------------------------------
@@ -543,13 +534,21 @@ def _menu(
             )
         )
 
+    actions.append(Action("status", "Show status", ""))
     actions.append(Action("quit", "Quit", ""))
     return actions
 
 
-def _opening(inv: inventory.Inventory, cat: catalog.Catalog) -> list[CheckRow]:
-    """Everything the flat commands would have told you, before being asked."""
+def show_status(
+    inv: inventory.Inventory, cat: catalog.Catalog, rows: list[CheckRow]
+) -> None:
+    """Everything the flat commands would have told you.
+
+    Drawn once on the way in, and again on request: a download scrolls it off
+    the screen, and the menu alone does not say what is already here.
+    """
     render.banner()
+    _echo_command("spells status")
 
     if _held(inv):
         render._render_status(
@@ -562,9 +561,8 @@ def _opening(inv: inventory.Inventory, cat: catalog.Catalog) -> list[CheckRow]:
 
     if cat.is_fallback:
         console.error("Could not reach 17Lands; only local actions are available.")
-        return []
+        return
 
-    rows = _check(inv, cat)
     stale = sorted({r.target.expansion for r in rows if r.freshness == Freshness.STALE})
     unadded = catalog.unadded(cat, _held(inv))
 
@@ -577,7 +575,22 @@ def _opening(inv: inventory.Inventory, cat: catalog.Catalog) -> list[CheckRow]:
         console.info("")
         console.info(f"{len(unadded)} set(s) published, not downloaded:")
         console.detail(", ".join(unadded[:NAMED]) + more)
+
+
+def _opening(inv: inventory.Inventory, cat: catalog.Catalog) -> list[CheckRow]:
+    rows = _check(inv, cat)
+    show_status(inv, cat, rows)
     return rows
+
+
+HANDLERS = {
+    "download": download,
+    "remove": remove,
+    "summon": try_summon,
+    "repair": free_space,
+    "cache": clear_cache,
+    "status": show_status,
+}
 
 
 def run() -> None:

--- a/spells/wizard.py
+++ b/spells/wizard.py
@@ -15,6 +15,7 @@ way out of being needed.
 from dataclasses import dataclass, replace
 
 import questionary
+from prompt_toolkit.keys import Keys
 
 from spells import cache, catalog, console, external, inventory, render, repair
 from spells.catalog import CheckRow, Freshness, Target
@@ -22,10 +23,6 @@ from spells.enums import EventType, View
 
 # how many set codes to name before the list stops fitting a narrow terminal
 NAMED = 4
-
-# an explicit way out of a multi-select, since "tick nothing and press enter"
-# is a thing you have to already know
-BACK = "__back__"
 
 # the current format and the one before it, ticked on a first run
 FIRST_RUN_SETS = 2
@@ -48,8 +45,25 @@ class Action:
     detail: str
 
 
+def _bind_escape(prompt) -> None:
+    """Make escape leave a prompt, which questionary does not bind itself.
+
+    Deliberately not eager: escape is also the first byte of every arrow-key
+    sequence, so firing on sight would break navigation. Non-eager lets
+    prompt_toolkit wait long enough to tell a lone escape from `esc [ A`.
+    """
+    bindings = getattr(getattr(prompt, "application", None), "key_bindings", None)
+    if bindings is None:
+        return
+
+    @bindings.add(Keys.Escape)
+    def _(event):
+        event.app.exit(result=None)
+
+
 def _ask(prompt) -> object | None:
-    """questionary returns None when interrupted; treat that as backing out."""
+    """None means the user left — escape, ctrl-c, or an empty selection."""
+    _bind_escape(prompt)
     try:
         return prompt.ask()
     except KeyboardInterrupt:
@@ -173,16 +187,6 @@ def _first_run_defaults(offered: list[Candidate]) -> list[Candidate]:
 # ---------------------------------------------------------------------------
 
 
-def _back_choice() -> questionary.Choice:
-    return questionary.Choice("← back, change nothing", value=BACK)
-
-
-def _backed_out(picked) -> bool:
-    """Backing out wins over anything else ticked: someone who selected it
-    meant to leave, whatever else the cursor passed over."""
-    return not picked or BACK in picked
-
-
 def _reasons_for(offers: list[Candidate], expansion: str) -> str:
     """Why a set is listed.
 
@@ -219,9 +223,8 @@ def download(
 
     picked_sets = _ask(
         questionary.checkbox(
-            "Which sets? (space toggles, enter confirms)",
-            choices=[_back_choice()]
-            + [
+            "Which sets to download? (esc goes back)",
+            choices=[
                 questionary.Choice(
                     f"{expansion:<16}{_reasons_for(offers, expansion)}",
                     value=expansion,
@@ -232,7 +235,7 @@ def download(
             qmark="  ",
         )
     )
-    if _backed_out(picked_sets):
+    if not picked_sets:
         return
 
     scoped = [c for c in offers if c.expansion in picked_sets]
@@ -240,9 +243,8 @@ def download(
     if len(event_types) > 1:
         picked_events = _ask(
             questionary.checkbox(
-                "Which event types?",
-                choices=[_back_choice()]
-                + [
+                "Which event types? (esc goes back)",
+                choices=[
                     questionary.Choice(
                         str(e),
                         value=e,
@@ -253,7 +255,7 @@ def download(
                 qmark="  ",
             )
         )
-        if _backed_out(picked_events):
+        if not picked_events:
             return
         scoped = [c for c in scoped if c.event_type in picked_events]
 
@@ -281,9 +283,8 @@ def remove(
 
     picked = _ask(
         questionary.checkbox(
-            "Remove which sets? (space toggles, enter confirms)",
-            choices=[_back_choice()]
-            + [
+            "Which sets to remove? (esc goes back)",
+            choices=[
                 questionary.Choice(
                     f"{code:<16}"
                     f"{console.sizeof_fmt(inv.sets[code].external_bytes):>10}  "
@@ -295,7 +296,7 @@ def remove(
             qmark="  ",
         )
     )
-    if _backed_out(picked):
+    if not picked:
         return
 
     freed = sum(inv.sets[c].total_bytes for c in picked)

--- a/spells/wizard.py
+++ b/spells/wizard.py
@@ -13,6 +13,9 @@ way out of being needed.
 """
 
 from dataclasses import dataclass, replace
+from pathlib import Path
+import runpy
+import shutil
 
 import questionary
 from prompt_toolkit.key_binding import KeyBindings, merge_key_bindings
@@ -430,6 +433,44 @@ def free_space(
         console.error(f"could not remove {path}: {error}")
 
 
+EXAMPLE = Path(__file__).parent / "examples" / "first_summon.py"
+
+
+def try_summon(
+    inv: inventory.Inventory, cat: catalog.Catalog, rows: list[CheckRow]
+) -> None:
+    """Run the example query, then offer to hand over the script.
+
+    Running it proves the install works on real data; keeping it is the point,
+    since the next thing anyone wants is the same query with different columns.
+    """
+    if not _held(inv):
+        console.info("Download a set first — there is nothing to summon yet.")
+        return
+
+    console.info("Aggregating every downloaded set. The first run is the slow one.")
+    _echo_command(f"python {EXAMPLE.name}")
+    console.info("")
+
+    try:
+        runpy.run_path(str(EXAMPLE), run_name="__main__")
+    except Exception as e:  # a broken query should not take the walkthrough down
+        console.error(f"{type(e).__name__}: {e}")
+        return
+
+    destination = Path.cwd() / EXAMPLE.name
+    question = (
+        f"Overwrite {destination}?"
+        if destination.exists()
+        else f"Copy the script to {destination}?"
+    )
+    if not _ask(questionary.confirm(question, default=False, qmark="  ")):
+        return
+
+    shutil.copy(EXAMPLE, destination)
+    console.info(f"Wrote {destination}")
+
+
 def clear_cache(
     inv: inventory.Inventory, cat: catalog.Catalog, rows: list[CheckRow]
 ) -> None:
@@ -457,6 +498,7 @@ def clear_cache(
 HANDLERS = {
     "download": download,
     "remove": remove,
+    "summon": try_summon,
     "repair": free_space,
     "cache": clear_cache,
 }
@@ -482,6 +524,9 @@ def _menu(
 
     if _held(inv):
         actions.append(Action("remove", "Remove datasets", ""))
+        actions.append(
+            Action("summon", "Run an example query", "check the install works")
+        )
 
     repairs = repair.plan(inv)
     if repairs:

--- a/spells/wizard.py
+++ b/spells/wizard.py
@@ -5,25 +5,36 @@ Everything here is a front end over `inventory`, `catalog`, `repair`, and
 having to know the commands exist, which is the whole problem for a first-time
 user staring at an empty data home.
 
-Two rules shape it. The menu offers only what the data home actually needs, so
-a set that is already current is never presented as a chore. And every action
-prints the command that would have done the same thing, so the wizard teaches
-its way out of being needed.
+Two rules shape it. The opening screen states everything the flat commands
+would have told you — what is on disk, and what 17Lands has that you do not —
+so the menu is a decision rather than an investigation. And every action prints
+the command that would have done the same thing, so the walkthrough teaches its
+way out of being needed.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 import questionary
 
-from spells import catalog, console, external, inventory, repair
-from spells.catalog import Freshness, Target
+from spells import catalog, console, external, inventory, render, repair
+from spells.catalog import CheckRow, Freshness, Target
 from spells.enums import EventType, View
 
-CANCEL = "cancel"
+# how many set codes to name before the list stops fitting a narrow terminal
+NAMED = 4
 
-# Long enough to scroll, short enough that a new user is not reading a wall of
-# expansions they have never heard of.
-BROWSE_LIMIT = 12
+# the current format and the one before it, ticked on a first run
+FIRST_RUN_SETS = 2
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One downloadable (set, event type), and why it is being offered."""
+
+    expansion: str
+    event_type: EventType
+    reason: str
+    wanted: bool
 
 
 @dataclass(frozen=True)
@@ -49,14 +60,19 @@ def _held(inv: inventory.Inventory) -> set[str]:
     return {s.set_code for s in inv.sets.values() if s.has_external}
 
 
-def _stale_targets(inv: inventory.Inventory, cat: catalog.Catalog) -> list[Target]:
+def _targets(inv: inventory.Inventory, cat: catalog.Catalog) -> list[Target]:
+    """Every published dataset for a set on disk, alongside what is there."""
     targets = []
     for set_inv in inv.sets.values():
         if not set_inv.has_external:
             continue
-        for event_type, files in set_inv.events.items():
-            for view in (View.DRAFT, View.GAME):
-                local = getattr(files, view, None)
+        published = {
+            d.event_type for d in cat.for_expansion(set_inv.set_code) if d.is_supported
+        }
+        for event_type in sorted(published | set(set_inv.events)):
+            files = set_inv.events.get(event_type)
+            for view in render.CHECKED_VIEWS:
+                local = getattr(files, view, None) if files else None
                 targets.append(
                     Target(
                         set_inv.set_code,
@@ -68,15 +84,77 @@ def _stale_targets(inv: inventory.Inventory, cat: catalog.Catalog) -> list[Targe
     return targets
 
 
-def _sets_needing_update(inv: inventory.Inventory, cat: catalog.Catalog) -> list[str]:
-    rows = catalog.resolve(_stale_targets(inv, cat), cat)
-    return sorted(
-        {
-            r.target.expansion
-            for r in rows
-            if r.freshness in (Freshness.STALE, Freshness.ABSENT)
-        }
+def _check(inv: inventory.Inventory, cat: catalog.Catalog) -> list[CheckRow]:
+    if cat.is_fallback:
+        return []
+    return catalog.resolve(_targets(inv, cat), cat)
+
+
+def candidates(
+    inv: inventory.Inventory, cat: catalog.Catalog, rows: list[CheckRow]
+) -> list[Candidate]:
+    """What is worth downloading, newest set first.
+
+    Pre-selected when it is an update to something tracked, a gap in a set
+    partly downloaded, or a set never added; left unticked when it is an event
+    type published for a set you have but evidently did not want.
+    """
+    tracked = {
+        (r.target.expansion, r.target.event_type)
+        for r in rows
+        if r.target.local_mtime is not None
+    }
+
+    offers: dict[tuple[str, EventType], tuple[str, bool]] = {}
+    for row in rows:
+        key = (row.target.expansion, row.target.event_type)
+        if row.freshness == Freshness.STALE:
+            offers[key] = ("update available", True)
+        elif row.freshness == Freshness.ABSENT and key not in offers:
+            offers[key] = (
+                ("incomplete", True) if key in tracked else ("not downloaded", False)
+            )
+
+    # "new" only means anything relative to what is already here, so on a first
+    # run nothing is new and everything is merely available.
+    started = bool(_held(inv))
+    for expansion in catalog.unadded(cat, _held(inv)):
+        for dataset in cat.for_expansion(expansion):
+            if dataset.is_supported and dataset.draft_url:
+                offers.setdefault(
+                    (expansion, dataset.event_type),
+                    (
+                        "new set" if started else "available",
+                        started and dataset.event_type == EventType.PREMIER,
+                    ),
+                )
+
+    order = {e: i for i, e in enumerate(catalog.in_release_order(cat, cat.expansions))}
+    offered = sorted(
+        (
+            Candidate(expansion, event_type, reason, wanted)
+            for (expansion, event_type), (reason, wanted) in offers.items()
+        ),
+        key=lambda c: (order.get(c.expansion, len(order)), str(c.event_type)),
     )
+    return offered if started else _first_run_defaults(offered)
+
+
+def _first_run_defaults(offered: list[Candidate]) -> list[Candidate]:
+    """Tick the current format and the one before it.
+
+    Every published set is unticked at this point, since none of them is new to
+    a data home with nothing in it. Leaving it there means a new user has to
+    know which codes are current before they can start, while ticking all of
+    them would put tens of gigabytes one keypress away.
+    """
+    newest = list(dict.fromkeys(c.expansion for c in offered))[:FIRST_RUN_SETS]
+    return [
+        replace(c, wanted=True)
+        if c.expansion in newest and c.event_type == EventType.PREMIER
+        else c
+        for c in offered
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -84,59 +162,18 @@ def _sets_needing_update(inv: inventory.Inventory, cat: catalog.Catalog) -> list
 # ---------------------------------------------------------------------------
 
 
-def _choose_expansion(cat: catalog.Catalog, held: set[str]) -> str | None:
-    candidates = [
-        e
-        for e in catalog.in_release_order(cat, cat.expansions)
-        if e not in held and cat.is_addable(e)
-    ]
-    if not candidates:
-        console.info("Every published set is already downloaded.")
-        return None
+def _reasons_for(offers: list[Candidate], expansion: str) -> str:
+    """Why a set is listed.
 
-    def label(expansion: str) -> str:
-        when = cat.updated(expansion)
-        return f"{expansion:<16}{when.isoformat() if when else ''}"
-
-    choices = [questionary.Choice(label(e), value=e) for e in candidates[:BROWSE_LIMIT]]
-    if len(candidates) > BROWSE_LIMIT:
-        choices.append(
-            questionary.Choice(
-                f"... {len(candidates) - BROWSE_LIMIT} older sets", value="__more__"
-            )
-        )
-    choices.append(questionary.Choice("Back", value=CANCEL))
-
-    picked = _ask(questionary.select("Which set?", choices=choices, qmark="  "))
-    if picked == "__more__":
-        picked = _ask(
-            questionary.select(
-                "Which set?",
-                choices=[questionary.Choice(label(e), value=e) for e in candidates]
-                + [questionary.Choice("Back", value=CANCEL)],
-                qmark="  ",
-            )
-        )
-    return None if picked in (None, CANCEL) else str(picked)
-
-
-def _choose_event_type(cat: catalog.Catalog, expansion: str) -> EventType | None:
-    published = [
-        d.event_type
-        for d in cat.for_expansion(expansion)
-        if d.is_supported and d.url(View.DRAFT)
-    ]
-    if len(published) == 1:
-        return published[0]
-
-    choices = [questionary.Choice(str(e), value=e) for e in published]
-    choices.append(questionary.Choice("Back", value=CANCEL))
-    picked = _ask(
-        questionary.select(
-            f"Which event type for {expansion}?", choices=choices, qmark="  "
-        )
-    )
-    return None if picked in (None, CANCEL) else picked
+    The reasons that pre-selected it, if any, since those are what the user is
+    being asked to agree with. Otherwise the event types on offer — saying "not
+    downloaded" next to a set you plainly have reads as though the whole thing
+    were missing, when only an event type is.
+    """
+    same_set = [c for c in offers if c.expansion == expansion]
+    if wanted := [c.reason for c in same_set if c.wanted]:
+        return ", ".join(dict.fromkeys(wanted))
+    return ", ".join(dict.fromkeys(str(c.event_type) for c in same_set))
 
 
 def _download_size(cat: catalog.Catalog, expansion: str, event_type: EventType) -> int:
@@ -151,62 +188,117 @@ def _download_size(cat: catalog.Catalog, expansion: str, event_type: EventType) 
     return total
 
 
-def add_set(inv: inventory.Inventory, cat: catalog.Catalog) -> None:
-    expansion = _choose_expansion(cat, _held(inv))
-    if expansion is None:
+def download(
+    inv: inventory.Inventory, cat: catalog.Catalog, rows: list[CheckRow]
+) -> None:
+    offers = candidates(inv, cat, rows)
+    if not offers:
+        console.info("Nothing to download; everything published is already here.")
         return
 
-    event_type = _choose_event_type(cat, expansion)
-    if event_type is None:
+    picked_sets = _ask(
+        questionary.checkbox(
+            "Which sets? (space toggles, enter confirms)",
+            choices=[
+                questionary.Choice(
+                    f"{expansion:<16}{_reasons_for(offers, expansion)}",
+                    value=expansion,
+                    checked=any(c.wanted for c in offers if c.expansion == expansion),
+                )
+                for expansion in dict.fromkeys(c.expansion for c in offers)
+            ],
+            qmark="  ",
+        )
+    )
+    if not picked_sets:
         return
 
-    size = _download_size(cat, expansion, event_type)
-    size_note = f" (~{console.sizeof_fmt(size)} compressed)" if size else ""
+    scoped = [c for c in offers if c.expansion in picked_sets]
+    event_types = sorted({c.event_type for c in scoped}, key=str)
+    if len(event_types) > 1:
+        picked_events = _ask(
+            questionary.checkbox(
+                "Which event types?",
+                choices=[
+                    questionary.Choice(
+                        str(e),
+                        value=e,
+                        checked=any(c.wanted for c in scoped if c.event_type == e),
+                    )
+                    for e in event_types
+                ],
+                qmark="  ",
+            )
+        )
+        if not picked_events:
+            return
+        scoped = [c for c in scoped if c.event_type in picked_events]
+
+    size = sum(_download_size(cat, c.expansion, c.event_type) for c in scoped)
+    note = f", ~{console.sizeof_fmt(size)} compressed" if size else ""
     if not _ask(
         questionary.confirm(
-            f"Download {expansion} {event_type}{size_note}?", default=True, qmark="  "
+            f"Download {len(scoped)} dataset(s){note}?", default=True, qmark="  "
         )
     ):
         return
 
-    _echo_command(f"spells add {expansion} {event_type}")
-    external._add(expansion, event_type=event_type)
+    for candidate in scoped:
+        _echo_command(f"spells add {candidate.expansion} {candidate.event_type}")
+        external._add(candidate.expansion, event_type=candidate.event_type)
 
 
-def update_sets(inv: inventory.Inventory, cat: catalog.Catalog) -> None:
-    stale = _sets_needing_update(inv, cat)
-    if not stale:
-        console.info("Everything you have is current.")
+def remove(
+    inv: inventory.Inventory, cat: catalog.Catalog, rows: list[CheckRow]
+) -> None:
+    held = sorted(_held(inv))
+    if not held:
+        console.info("Nothing downloaded.")
         return
 
     picked = _ask(
         questionary.checkbox(
-            "Which sets should be brought up to date?",
-            choices=[questionary.Choice(s, value=s, checked=True) for s in stale],
+            "Remove which sets? (space toggles, enter confirms)",
+            choices=[
+                questionary.Choice(
+                    f"{code:<16}"
+                    f"{console.sizeof_fmt(inv.sets[code].external_bytes):>10}  "
+                    f"{', '.join(str(e) for e in inv.sets[code].events)}",
+                    value=code,
+                )
+                for code in held
+            ],
             qmark="  ",
         )
     )
     if not picked:
         return
 
-    for expansion in picked:
-        set_inv = inv.sets.get(expansion)
-        events = list(set_inv.events) if set_inv else [EventType.PREMIER]
-        for event_type in events:
-            _echo_command(f"spells add {expansion} {event_type}")
-            external._add(expansion, event_type=event_type)
+    freed = sum(inv.sets[c].total_bytes for c in picked)
+    if not _ask(
+        questionary.confirm(
+            f"Delete {len(picked)} set(s), freeing {console.sizeof_fmt(freed)}?",
+            default=False,
+            qmark="  ",
+        )
+    ):
+        return
+
+    for code in picked:
+        _echo_command(f"spells remove {code} --yes")
+        external._remove(code)
 
 
-def free_space(inv: inventory.Inventory, cat: catalog.Catalog) -> None:
+def free_space(
+    inv: inventory.Inventory, cat: catalog.Catalog, rows: list[CheckRow]
+) -> None:
     repairs = repair.plan(inv)
     if not repairs:
         console.info("Nothing to clean up.")
         return
 
+    render._render_repairs(repairs)
     files = sum(r.files for r in repairs)
-    freed = sum(r.size for r in repairs)
-    console.info(f"{files} unusable file(s) taking {console.sizeof_fmt(freed)}.")
-
     if not _ask(
         questionary.confirm(f"Delete {files} file(s)?", default=False, qmark="  ")
     ):
@@ -221,105 +313,96 @@ def free_space(inv: inventory.Inventory, cat: catalog.Catalog) -> None:
         console.error(f"could not remove {path}: {error}")
 
 
-def show_summary(inv: inventory.Inventory, cat: catalog.Catalog) -> None:
-    _echo_command("spells status")
-    sets = [s for s in inv.sets.values() if s.has_external]
-    console.info(
-        f"{len(sets)} set(s), {console.sizeof_fmt(inv.total_bytes)} in {inv.data_home}"
-    )
-    for set_inv in sorted(sets, key=lambda s: s.set_code):
-        events = ", ".join(str(e) for e in set_inv.events)
-        console.detail(f"{set_inv.set_code:<16}{events}")
+HANDLERS = {"download": download, "remove": remove, "clean": free_space}
 
 
 # ---------------------------------------------------------------------------
-# Flows
+# Flow
 # ---------------------------------------------------------------------------
 
 
-def _bootstrap(cat: catalog.Catalog) -> None:
-    """First run: there is nothing on disk, so there is exactly one useful
-    thing to do and no menu is worth showing."""
-    console.info("No 17Lands data here yet.")
-    console.detail("spells keeps draft and game datasets under this directory,")
-    console.detail("then answers questions about them with `summon`.\n")
-
-    add_set(inventory.scan(), cat)
-
-    inv = inventory.scan()
-    if any(s.has_external for s in inv.sets.values()):
-        console.info("\nReady. From here:")
-        console.detail("spells status        what you have")
-        console.detail("spells check         whether 17Lands has anything newer")
-        console.detail("spells              this walkthrough again")
-
-
-def _menu(inv: inventory.Inventory, cat: catalog.Catalog) -> list[Action]:
-    """Only what this data home actually needs, so nothing already fine is
-    offered as a task."""
+def _menu(
+    inv: inventory.Inventory, cat: catalog.Catalog, rows: list[CheckRow]
+) -> list[Action]:
+    """Only what this data home actually offers, so nothing already fine is
+    presented as a chore."""
     actions = []
 
-    unadded = catalog.unadded(cat, _held(inv))
-    if unadded:
-        actions.append(
-            Action("add", "Add a set", f"{len(unadded)} published, not downloaded")
-        )
-    else:
-        actions.append(Action("add", "Add a set", ""))
+    offers = candidates(inv, cat, rows)
+    if offers:
+        wanted = sum(1 for c in offers if c.wanted)
+        detail = f"{wanted} suggested" if wanted else f"{len(offers)} available"
+        actions.append(Action("download", "Download datasets", detail))
 
-    stale = _sets_needing_update(inv, cat)
-    if stale:
-        actions.append(
-            Action("update", "Update out-of-date data", f"{len(stale)} set(s)")
-        )
+    if _held(inv):
+        actions.append(Action("remove", "Remove datasets", ""))
 
     repairs = repair.plan(inv)
     if repairs:
-        freed = sum(r.size for r in repairs)
-        actions.append(
-            Action("clean", "Free up space", f"{console.sizeof_fmt(freed)} unusable")
-        )
+        freed = console.sizeof_fmt(sum(r.size for r in repairs))
+        actions.append(Action("clean", "Free up space", f"{freed} unusable"))
 
-    actions.append(Action("summary", "Show what I have", ""))
     actions.append(Action("quit", "Quit", ""))
     return actions
 
 
-HANDLERS = {
-    "add": add_set,
-    "update": update_sets,
-    "clean": free_space,
-    "summary": show_summary,
-}
+def _opening(inv: inventory.Inventory, cat: catalog.Catalog) -> list[CheckRow]:
+    """Everything the flat commands would have told you, before being asked."""
+    render.banner()
+
+    if _held(inv):
+        render._render_status(
+            inv, list(inv.sets.values()), inv.all_anomalies, detailed=False
+        )
+    else:
+        console.info(f"No 17Lands data yet in {inv.data_home}")
+        console.detail("spells keeps draft and game datasets there,")
+        console.detail("then answers questions about them with `summon`.")
+
+    if cat.is_fallback:
+        console.error("Could not reach 17Lands; only local actions are available.")
+        return []
+
+    rows = _check(inv, cat)
+    stale = sorted({r.target.expansion for r in rows if r.freshness == Freshness.STALE})
+    unadded = catalog.unadded(cat, _held(inv))
+
+    if stale:
+        console.info("")
+        console.info(f"{len(stale)} set(s) have newer data:")
+        console.detail(", ".join(stale))
+    if unadded:
+        more = f", +{len(unadded) - NAMED} more" if len(unadded) > NAMED else ""
+        console.info("")
+        console.info(f"{len(unadded)} set(s) published, not downloaded:")
+        console.detail(", ".join(unadded[:NAMED]) + more)
+    return rows
 
 
 def run() -> None:
     """Entry point for a bare `spells` at a terminal."""
     cat = catalog.fetch()
-    if cat.is_fallback:
-        console.error("Could not reach 17Lands; only local actions are available.")
-
     inv = inventory.scan()
-    if not any(s.has_external for s in inv.sets.values()):
-        _bootstrap(cat)
-        return
+    rows = _opening(inv, cat)
 
     while True:
-        inv = inventory.scan()
-        actions = _menu(inv, cat)
+        console.info("")
         choice = _ask(
             questionary.select(
                 "What would you like to do?",
                 choices=[
                     questionary.Choice(
-                        f"{a.label:<26}{a.detail}" if a.detail else a.label, value=a.key
+                        f"{a.label:<22}{a.detail}" if a.detail else a.label,
+                        value=a.key,
                     )
-                    for a in actions
+                    for a in _menu(inv, cat, rows)
                 ],
                 qmark="  ",
             )
         )
         if choice in (None, "quit"):
             return
-        HANDLERS[str(choice)](inv, cat)
-        console.info("")
+
+        HANDLERS[str(choice)](inv, cat, rows)
+        inv = inventory.scan()
+        rows = _check(inv, cat)

--- a/spells/wizard.py
+++ b/spells/wizard.py
@@ -15,7 +15,6 @@ way out of being needed.
 from dataclasses import dataclass, replace
 
 import questionary
-from prompt_toolkit.keys import Keys
 
 from spells import cache, catalog, console, external, inventory, render, repair
 from spells.catalog import CheckRow, Freshness, Target
@@ -23,6 +22,13 @@ from spells.enums import EventType, View
 
 # how many set codes to name before the list stops fitting a narrow terminal
 NAMED = 4
+
+BACK_KEY = "b"
+QUIT_KEY = "q"
+
+# questionary writes this line itself but cannot mention keys it does not know
+# about, so the whole thing is replaced rather than added to
+PICK_KEYS = "(arrows move, <space> select, <a> all, <i> invert, <b> back, <q> quit)"
 
 # the current format and the one before it, ticked on a first run
 FIRST_RUN_SETS = 2
@@ -45,25 +51,39 @@ class Action:
     detail: str
 
 
-def _bind_escape(prompt) -> None:
-    """Make escape leave a prompt, which questionary does not bind itself.
+class Quit(Exception):
+    """Raised out of a prompt to leave the walkthrough entirely.
 
-    Deliberately not eager: escape is also the first byte of every arrow-key
-    sequence, so firing on sight would break navigation. Non-eager lets
-    prompt_toolkit wait long enough to tell a lone escape from `esc [ A`.
+    An exception rather than a sentinel return, so quitting from three prompts
+    deep does not need every step in between to recognize and forward it — the
+    same way questionary itself handles ctrl-c.
+    """
+
+
+def _bind_keys(prompt) -> None:
+    """Add `b` and `q`, which questionary has no keys for.
+
+    Eager, like questionary's own `a` and `i`: an ordinary letter needs no
+    disambiguation. Escape would read more naturally but is the first byte of
+    every arrow-key sequence, so it cannot be answered until prompt_toolkit has
+    waited to see whether more follows.
     """
     bindings = getattr(getattr(prompt, "application", None), "key_bindings", None)
     if bindings is None:
         return
 
-    @bindings.add(Keys.Escape)
-    def _(event):
+    @bindings.add(BACK_KEY, eager=True)
+    def _back(event):
         event.app.exit(result=None)
+
+    @bindings.add(QUIT_KEY, eager=True)
+    def _quit(event):
+        event.app.exit(exception=Quit)
 
 
 def _ask(prompt) -> object | None:
-    """None means the user left — escape, ctrl-c, or an empty selection."""
-    _bind_escape(prompt)
+    """None means the user backed out — `b`, ctrl-c, or an empty selection."""
+    _bind_keys(prompt)
     try:
         return prompt.ask()
     except KeyboardInterrupt:
@@ -223,7 +243,8 @@ def download(
 
     picked_sets = _ask(
         questionary.checkbox(
-            "Which sets to download? (esc goes back)",
+            "Which sets to download?",
+            instruction=PICK_KEYS,
             choices=[
                 questionary.Choice(
                     f"{expansion:<16}{_reasons_for(offers, expansion)}",
@@ -243,7 +264,8 @@ def download(
     if len(event_types) > 1:
         picked_events = _ask(
             questionary.checkbox(
-                "Which event types? (esc goes back)",
+                "Which event types?",
+                instruction=PICK_KEYS,
                 choices=[
                     questionary.Choice(
                         str(e),
@@ -283,7 +305,8 @@ def remove(
 
     picked = _ask(
         questionary.checkbox(
-            "Which sets to remove? (esc goes back)",
+            "Which sets to remove?",
+            instruction=PICK_KEYS,
             choices=[
                 questionary.Choice(
                     f"{code:<16}"
@@ -447,26 +470,29 @@ def run() -> None:
     """Entry point for a bare `spells` at a terminal."""
     cat = catalog.fetch()
     inv = inventory.scan()
-    rows = _opening(inv, cat)
 
-    while True:
-        console.info("")
-        choice = _ask(
-            questionary.select(
-                "What would you like to do?",
-                choices=[
-                    questionary.Choice(
-                        f"{a.label:<22}{a.detail}" if a.detail else a.label,
-                        value=a.key,
-                    )
-                    for a in _menu(inv, cat, rows)
-                ],
-                qmark="  ",
+    try:
+        rows = _opening(inv, cat)
+        while True:
+            console.info("")
+            choice = _ask(
+                questionary.select(
+                    "What would you like to do?",
+                    choices=[
+                        questionary.Choice(
+                            f"{a.label:<22}{a.detail}" if a.detail else a.label,
+                            value=a.key,
+                        )
+                        for a in _menu(inv, cat, rows)
+                    ],
+                    qmark="  ",
+                )
             )
-        )
-        if choice in (None, "quit"):
-            return
+            if choice in (None, "quit"):
+                return
 
-        HANDLERS[str(choice)](inv, cat, rows)
-        inv = inventory.scan()
-        rows = _check(inv, cat)
+            HANDLERS[str(choice)](inv, cat, rows)
+            inv = inventory.scan()
+            rows = _check(inv, cat)
+    except Quit:
+        return

--- a/spells/wizard.py
+++ b/spells/wizard.py
@@ -15,6 +15,7 @@ way out of being needed.
 from dataclasses import dataclass, replace
 
 import questionary
+from prompt_toolkit.key_binding import KeyBindings, merge_key_bindings
 
 from spells import cache, catalog, console, external, inventory, render, repair
 from spells.catalog import CheckRow, Freshness, Target
@@ -63,22 +64,30 @@ class Quit(Exception):
 def _bind_keys(prompt) -> None:
     """Add `b` and `q`, which questionary has no keys for.
 
+    Merged rather than added to: `confirm` is built on a PromptSession, which
+    combines its own bindings with questionary's and hands the application an
+    already-merged set that cannot be appended to.
+
     Eager, like questionary's own `a` and `i`: an ordinary letter needs no
     disambiguation. Escape would read more naturally but is the first byte of
     every arrow-key sequence, so it cannot be answered until prompt_toolkit has
     waited to see whether more follows.
     """
-    bindings = getattr(getattr(prompt, "application", None), "key_bindings", None)
-    if bindings is None:
+    app = getattr(prompt, "application", None)
+    if app is None or getattr(app, "key_bindings", None) is None:
         return
 
-    @bindings.add(BACK_KEY, eager=True)
+    extra = KeyBindings()
+
+    @extra.add(BACK_KEY, eager=True)
     def _back(event):
         event.app.exit(result=None)
 
-    @bindings.add(QUIT_KEY, eager=True)
+    @extra.add(QUIT_KEY, eager=True)
     def _quit(event):
         event.app.exit(exception=Quit)
+
+    app.key_bindings = merge_key_bindings([app.key_bindings, extra])
 
 
 def _ask(prompt) -> object | None:
@@ -295,6 +304,30 @@ def download(
         external._add(candidate.expansion, event_type=candidate.event_type)
 
 
+def _removal_size(
+    inv: inventory.Inventory, code: str, event_types: list[EventType]
+) -> int:
+    """Bytes freed by dropping these event types from one set.
+
+    The card file and derived cache only count when the last event type goes,
+    since those survive a partial removal.
+    """
+    set_inv = inv.sets[code]
+    wanted = [e for e in set_inv.events if e in event_types]
+    if set(wanted) == set(set_inv.events):
+        return set_inv.total_bytes
+
+    return sum(
+        info.size
+        for event_type in wanted
+        for info in (
+            getattr(set_inv.events[event_type], view)
+            for view in inventory.DATASET_VIEWS
+        )
+        if info is not None
+    )
+
+
 def remove(
     inv: inventory.Inventory, cat: catalog.Catalog, rows: list[CheckRow]
 ) -> None:
@@ -322,10 +355,38 @@ def remove(
     if not picked:
         return
 
-    freed = sum(inv.sets[c].total_bytes for c in picked)
+    held_events = sorted({e for c in picked for e in inv.sets[c].events}, key=str)
+    if len(held_events) > 1:
+        picked_events = _ask(
+            questionary.checkbox(
+                "Which event types?",
+                instruction=PICK_KEYS,
+                choices=[
+                    questionary.Choice(str(e), value=e, checked=True)
+                    for e in held_events
+                ],
+                qmark="  ",
+            )
+        )
+        if not picked_events:
+            return
+        held_events = list(picked_events)
+
+    targets = [
+        (code, event_type)
+        for code in picked
+        for event_type in inv.sets[code].events
+        if event_type in held_events
+    ]
+    if not targets:
+        console.info("Nothing selected on disk.")
+        return
+
+    freed = sum(_removal_size(inv, code, held_events) for code in picked)
     if not _ask(
         questionary.confirm(
-            f"Delete {len(picked)} set(s), freeing {console.sizeof_fmt(freed)}?",
+            f"Delete {len(targets)} dataset(s), freeing "
+            f"{console.sizeof_fmt(freed)}?",
             default=False,
             qmark="  ",
         )
@@ -333,8 +394,16 @@ def remove(
         return
 
     for code in picked:
-        _echo_command(f"spells remove {code} --yes")
-        external._remove(code)
+        wanted = [e for e in inv.sets[code].events if e in held_events]
+        # taking every event type takes the card file and directory with it,
+        # which the whole-set path already does
+        if set(wanted) == set(inv.sets[code].events):
+            _echo_command(f"spells remove {code} --yes")
+            external._remove(code)
+        else:
+            for event_type in wanted:
+                _echo_command(f"spells remove {code} {event_type}")
+                external._remove_event_type(code, event_type)
 
 
 def free_space(

--- a/spells/wizard.py
+++ b/spells/wizard.py
@@ -16,12 +16,16 @@ from dataclasses import dataclass, replace
 
 import questionary
 
-from spells import catalog, console, external, inventory, render, repair
+from spells import cache, catalog, console, external, inventory, render, repair
 from spells.catalog import CheckRow, Freshness, Target
 from spells.enums import EventType, View
 
 # how many set codes to name before the list stops fitting a narrow terminal
 NAMED = 4
+
+# an explicit way out of a multi-select, since "tick nothing and press enter"
+# is a thing you have to already know
+BACK = "__back__"
 
 # the current format and the one before it, ticked on a first run
 FIRST_RUN_SETS = 2
@@ -54,6 +58,13 @@ def _ask(prompt) -> object | None:
 
 def _echo_command(command: str) -> None:
     console.info(f"[dim]$[/dim] [bold]{command}[/bold]")
+
+
+def _cache_totals(inv: inventory.Inventory) -> tuple[int, int]:
+    return (
+        sum(s.cache_files for s in inv.sets.values()),
+        sum(s.cache_bytes for s in inv.sets.values()),
+    )
 
 
 def _held(inv: inventory.Inventory) -> set[str]:
@@ -162,6 +173,16 @@ def _first_run_defaults(offered: list[Candidate]) -> list[Candidate]:
 # ---------------------------------------------------------------------------
 
 
+def _back_choice() -> questionary.Choice:
+    return questionary.Choice("← back, change nothing", value=BACK)
+
+
+def _backed_out(picked) -> bool:
+    """Backing out wins over anything else ticked: someone who selected it
+    meant to leave, whatever else the cursor passed over."""
+    return not picked or BACK in picked
+
+
 def _reasons_for(offers: list[Candidate], expansion: str) -> str:
     """Why a set is listed.
 
@@ -199,7 +220,8 @@ def download(
     picked_sets = _ask(
         questionary.checkbox(
             "Which sets? (space toggles, enter confirms)",
-            choices=[
+            choices=[_back_choice()]
+            + [
                 questionary.Choice(
                     f"{expansion:<16}{_reasons_for(offers, expansion)}",
                     value=expansion,
@@ -210,7 +232,7 @@ def download(
             qmark="  ",
         )
     )
-    if not picked_sets:
+    if _backed_out(picked_sets):
         return
 
     scoped = [c for c in offers if c.expansion in picked_sets]
@@ -219,7 +241,8 @@ def download(
         picked_events = _ask(
             questionary.checkbox(
                 "Which event types?",
-                choices=[
+                choices=[_back_choice()]
+                + [
                     questionary.Choice(
                         str(e),
                         value=e,
@@ -230,7 +253,7 @@ def download(
                 qmark="  ",
             )
         )
-        if not picked_events:
+        if _backed_out(picked_events):
             return
         scoped = [c for c in scoped if c.event_type in picked_events]
 
@@ -259,7 +282,8 @@ def remove(
     picked = _ask(
         questionary.checkbox(
             "Remove which sets? (space toggles, enter confirms)",
-            choices=[
+            choices=[_back_choice()]
+            + [
                 questionary.Choice(
                     f"{code:<16}"
                     f"{console.sizeof_fmt(inv.sets[code].external_bytes):>10}  "
@@ -271,7 +295,7 @@ def remove(
             qmark="  ",
         )
     )
-    if not picked:
+    if _backed_out(picked):
         return
 
     freed = sum(inv.sets[c].total_bytes for c in picked)
@@ -313,7 +337,36 @@ def free_space(
         console.error(f"could not remove {path}: {error}")
 
 
-HANDLERS = {"download": download, "remove": remove, "clean": free_space}
+def clear_cache(
+    inv: inventory.Inventory, cat: catalog.Catalog, rows: list[CheckRow]
+) -> None:
+    """Derived query results only. They rebuild on demand, so this needs no
+    per-set choice — the only question is whether to reclaim the space."""
+    files, size = _cache_totals(inv)
+    if not files:
+        console.info("No derived cache to clear.")
+        return
+
+    if not _ask(
+        questionary.confirm(
+            f"Clear {files} cached result(s), {console.sizeof_fmt(size)}? "
+            "They rebuild on demand.",
+            default=True,
+            qmark="  ",
+        )
+    ):
+        return
+
+    _echo_command("spells clean all")
+    cache.clean("all")
+
+
+HANDLERS = {
+    "download": download,
+    "remove": remove,
+    "repair": free_space,
+    "cache": clear_cache,
+}
 
 
 # ---------------------------------------------------------------------------
@@ -340,7 +393,17 @@ def _menu(
     repairs = repair.plan(inv)
     if repairs:
         freed = console.sizeof_fmt(sum(r.size for r in repairs))
-        actions.append(Action("clean", "Free up space", f"{freed} unusable"))
+        actions.append(Action("repair", "Remove unusable files", freed))
+
+    files, size = _cache_totals(inv)
+    if files:
+        actions.append(
+            Action(
+                "cache",
+                "Clear derived cache",
+                f"{console.sizeof_fmt(size)}, rebuilds on demand",
+            )
+        )
 
     actions.append(Action("quit", "Quit", ""))
     return actions

--- a/spells/wizard.py
+++ b/spells/wizard.py
@@ -1,0 +1,325 @@
+"""The interactive walkthrough behind a bare `spells`.
+
+Everything here is a front end over `inventory`, `catalog`, `repair`, and
+`external`; nothing does work the flat commands cannot. What it adds is not
+having to know the commands exist, which is the whole problem for a first-time
+user staring at an empty data home.
+
+Two rules shape it. The menu offers only what the data home actually needs, so
+a set that is already current is never presented as a chore. And every action
+prints the command that would have done the same thing, so the wizard teaches
+its way out of being needed.
+"""
+
+from dataclasses import dataclass
+
+import questionary
+
+from spells import catalog, console, external, inventory, repair
+from spells.catalog import Freshness, Target
+from spells.enums import EventType, View
+
+CANCEL = "cancel"
+
+# Long enough to scroll, short enough that a new user is not reading a wall of
+# expansions they have never heard of.
+BROWSE_LIMIT = 12
+
+
+@dataclass(frozen=True)
+class Action:
+    key: str
+    label: str
+    detail: str
+
+
+def _ask(prompt) -> object | None:
+    """questionary returns None when interrupted; treat that as backing out."""
+    try:
+        return prompt.ask()
+    except KeyboardInterrupt:
+        return None
+
+
+def _echo_command(command: str) -> None:
+    console.info(f"[dim]$[/dim] [bold]{command}[/bold]")
+
+
+def _held(inv: inventory.Inventory) -> set[str]:
+    return {s.set_code for s in inv.sets.values() if s.has_external}
+
+
+def _stale_targets(inv: inventory.Inventory, cat: catalog.Catalog) -> list[Target]:
+    targets = []
+    for set_inv in inv.sets.values():
+        if not set_inv.has_external:
+            continue
+        for event_type, files in set_inv.events.items():
+            for view in (View.DRAFT, View.GAME):
+                local = getattr(files, view, None)
+                targets.append(
+                    Target(
+                        set_inv.set_code,
+                        event_type,
+                        view,
+                        local.mtime if local else None,
+                    )
+                )
+    return targets
+
+
+def _sets_needing_update(inv: inventory.Inventory, cat: catalog.Catalog) -> list[str]:
+    rows = catalog.resolve(_stale_targets(inv, cat), cat)
+    return sorted(
+        {
+            r.target.expansion
+            for r in rows
+            if r.freshness in (Freshness.STALE, Freshness.ABSENT)
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Actions
+# ---------------------------------------------------------------------------
+
+
+def _choose_expansion(cat: catalog.Catalog, held: set[str]) -> str | None:
+    candidates = [
+        e
+        for e in catalog.in_release_order(cat, cat.expansions)
+        if e not in held and cat.is_addable(e)
+    ]
+    if not candidates:
+        console.info("Every published set is already downloaded.")
+        return None
+
+    def label(expansion: str) -> str:
+        when = cat.updated(expansion)
+        return f"{expansion:<16}{when.isoformat() if when else ''}"
+
+    choices = [questionary.Choice(label(e), value=e) for e in candidates[:BROWSE_LIMIT]]
+    if len(candidates) > BROWSE_LIMIT:
+        choices.append(
+            questionary.Choice(
+                f"... {len(candidates) - BROWSE_LIMIT} older sets", value="__more__"
+            )
+        )
+    choices.append(questionary.Choice("Back", value=CANCEL))
+
+    picked = _ask(questionary.select("Which set?", choices=choices, qmark="  "))
+    if picked == "__more__":
+        picked = _ask(
+            questionary.select(
+                "Which set?",
+                choices=[questionary.Choice(label(e), value=e) for e in candidates]
+                + [questionary.Choice("Back", value=CANCEL)],
+                qmark="  ",
+            )
+        )
+    return None if picked in (None, CANCEL) else str(picked)
+
+
+def _choose_event_type(cat: catalog.Catalog, expansion: str) -> EventType | None:
+    published = [
+        d.event_type
+        for d in cat.for_expansion(expansion)
+        if d.is_supported and d.url(View.DRAFT)
+    ]
+    if len(published) == 1:
+        return published[0]
+
+    choices = [questionary.Choice(str(e), value=e) for e in published]
+    choices.append(questionary.Choice("Back", value=CANCEL))
+    picked = _ask(
+        questionary.select(
+            f"Which event type for {expansion}?", choices=choices, qmark="  "
+        )
+    )
+    return None if picked in (None, CANCEL) else picked
+
+
+def _download_size(cat: catalog.Catalog, expansion: str, event_type: EventType) -> int:
+    dataset = cat.get(expansion, event_type)
+    if dataset is None:
+        return 0
+    total = 0
+    for view in (View.DRAFT, View.GAME):
+        url = dataset.url(view)
+        remote = catalog.head(url) if url else None
+        total += remote.size if remote and remote.size else 0
+    return total
+
+
+def add_set(inv: inventory.Inventory, cat: catalog.Catalog) -> None:
+    expansion = _choose_expansion(cat, _held(inv))
+    if expansion is None:
+        return
+
+    event_type = _choose_event_type(cat, expansion)
+    if event_type is None:
+        return
+
+    size = _download_size(cat, expansion, event_type)
+    size_note = f" (~{console.sizeof_fmt(size)} compressed)" if size else ""
+    if not _ask(
+        questionary.confirm(
+            f"Download {expansion} {event_type}{size_note}?", default=True, qmark="  "
+        )
+    ):
+        return
+
+    _echo_command(f"spells add {expansion} {event_type}")
+    external._add(expansion, event_type=event_type)
+
+
+def update_sets(inv: inventory.Inventory, cat: catalog.Catalog) -> None:
+    stale = _sets_needing_update(inv, cat)
+    if not stale:
+        console.info("Everything you have is current.")
+        return
+
+    picked = _ask(
+        questionary.checkbox(
+            "Which sets should be brought up to date?",
+            choices=[questionary.Choice(s, value=s, checked=True) for s in stale],
+            qmark="  ",
+        )
+    )
+    if not picked:
+        return
+
+    for expansion in picked:
+        set_inv = inv.sets.get(expansion)
+        events = list(set_inv.events) if set_inv else [EventType.PREMIER]
+        for event_type in events:
+            _echo_command(f"spells add {expansion} {event_type}")
+            external._add(expansion, event_type=event_type)
+
+
+def free_space(inv: inventory.Inventory, cat: catalog.Catalog) -> None:
+    repairs = repair.plan(inv)
+    if not repairs:
+        console.info("Nothing to clean up.")
+        return
+
+    files = sum(r.files for r in repairs)
+    freed = sum(r.size for r in repairs)
+    console.info(f"{files} unusable file(s) taking {console.sizeof_fmt(freed)}.")
+
+    if not _ask(
+        questionary.confirm(f"Delete {files} file(s)?", default=False, qmark="  ")
+    ):
+        return
+
+    _echo_command("spells doctor --yes")
+    outcome = repair.apply(repairs)
+    console.info(
+        f"Removed {outcome.removed} file(s), freed {console.sizeof_fmt(outcome.freed)}."
+    )
+    for path, error in outcome.failures:
+        console.error(f"could not remove {path}: {error}")
+
+
+def show_summary(inv: inventory.Inventory, cat: catalog.Catalog) -> None:
+    _echo_command("spells status")
+    sets = [s for s in inv.sets.values() if s.has_external]
+    console.info(
+        f"{len(sets)} set(s), {console.sizeof_fmt(inv.total_bytes)} in {inv.data_home}"
+    )
+    for set_inv in sorted(sets, key=lambda s: s.set_code):
+        events = ", ".join(str(e) for e in set_inv.events)
+        console.detail(f"{set_inv.set_code:<16}{events}")
+
+
+# ---------------------------------------------------------------------------
+# Flows
+# ---------------------------------------------------------------------------
+
+
+def _bootstrap(cat: catalog.Catalog) -> None:
+    """First run: there is nothing on disk, so there is exactly one useful
+    thing to do and no menu is worth showing."""
+    console.info("No 17Lands data here yet.")
+    console.detail("spells keeps draft and game datasets under this directory,")
+    console.detail("then answers questions about them with `summon`.\n")
+
+    add_set(inventory.scan(), cat)
+
+    inv = inventory.scan()
+    if any(s.has_external for s in inv.sets.values()):
+        console.info("\nReady. From here:")
+        console.detail("spells status        what you have")
+        console.detail("spells check         whether 17Lands has anything newer")
+        console.detail("spells              this walkthrough again")
+
+
+def _menu(inv: inventory.Inventory, cat: catalog.Catalog) -> list[Action]:
+    """Only what this data home actually needs, so nothing already fine is
+    offered as a task."""
+    actions = []
+
+    unadded = catalog.unadded(cat, _held(inv))
+    if unadded:
+        actions.append(
+            Action("add", "Add a set", f"{len(unadded)} published, not downloaded")
+        )
+    else:
+        actions.append(Action("add", "Add a set", ""))
+
+    stale = _sets_needing_update(inv, cat)
+    if stale:
+        actions.append(
+            Action("update", "Update out-of-date data", f"{len(stale)} set(s)")
+        )
+
+    repairs = repair.plan(inv)
+    if repairs:
+        freed = sum(r.size for r in repairs)
+        actions.append(
+            Action("clean", "Free up space", f"{console.sizeof_fmt(freed)} unusable")
+        )
+
+    actions.append(Action("summary", "Show what I have", ""))
+    actions.append(Action("quit", "Quit", ""))
+    return actions
+
+
+HANDLERS = {
+    "add": add_set,
+    "update": update_sets,
+    "clean": free_space,
+    "summary": show_summary,
+}
+
+
+def run() -> None:
+    """Entry point for a bare `spells` at a terminal."""
+    cat = catalog.fetch()
+    if cat.is_fallback:
+        console.error("Could not reach 17Lands; only local actions are available.")
+
+    inv = inventory.scan()
+    if not any(s.has_external for s in inv.sets.values()):
+        _bootstrap(cat)
+        return
+
+    while True:
+        inv = inventory.scan()
+        actions = _menu(inv, cat)
+        choice = _ask(
+            questionary.select(
+                "What would you like to do?",
+                choices=[
+                    questionary.Choice(
+                        f"{a.label:<26}{a.detail}" if a.detail else a.label, value=a.key
+                    )
+                    for a in actions
+                ],
+                qmark="  ",
+            )
+        )
+        if choice in (None, "quit"):
+            return
+        HANDLERS[str(choice)](inv, cat)
+        console.info("")

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -617,3 +617,20 @@ def test_cards_does_not_report_itself_as_add(card_set):
     output = runner.invoke(cli.app, ["cards", "TST"]).output
     assert "Checking card file" in output
     assert "add" not in output.split("Checking")[0]
+
+
+def test_status_omits_the_snapshots_column_when_there_are_none(data_home):
+    """Snapshots only exist for callers of the private ratings API, so for most
+    users the column is a header over a column of dashes."""
+    out = runner.invoke(cli.app, ["status"]).output
+
+    assert "snapshots" not in out
+    assert "event types" in out
+
+
+def test_status_shows_the_snapshots_column_when_there_are_some(data_home):
+    snaps = data_home / "ratings" / "TST"
+    snaps.mkdir(parents=True)
+    (snaps / "PremierDraft_all_any_ALL_TIME_2026-07-14.json").write_text("[]")
+
+    assert "snapshots" in runner.invoke(cli.app, ["status"]).output

--- a/tests/external_test.py
+++ b/tests/external_test.py
@@ -201,3 +201,51 @@ def test_write_card_file_raises_on_inconsistent_names(tmp_path, monkeypatch):
 
     with pytest.raises(ValueError, match="inconsistent"):
         write_card_file("TST", ["Card A", "Card C"])
+
+
+def _write_set(home, set_code, *event_types):
+    d = home / "external" / set_code
+    d.mkdir(parents=True, exist_ok=True)
+    for event_type in event_types:
+        for view in ("draft", "game", "context"):
+            (d / f"{set_code}_{event_type}_{view}.parquet").write_bytes(b"x" * 10)
+    (d / f"{set_code}_card.parquet").write_bytes(b"x" * 10)
+    return d
+
+
+def test_remove_event_type_keeps_the_rest_of_the_set(tmp_path, monkeypatch):
+    monkeypatch.setenv("SPELLS_DATA_HOME", str(tmp_path))
+    d = _write_set(tmp_path, "TST", EventType.PREMIER, EventType.TRADITIONAL)
+
+    assert external._remove_event_type("TST", EventType.TRADITIONAL) == 0
+
+    left = sorted(p.name for p in d.iterdir())
+    assert not any(str(EventType.TRADITIONAL) in name for name in left)
+    assert any(str(EventType.PREMIER) in name for name in left)
+    assert "TST_card.parquet" in left
+
+
+def test_remove_event_type_takes_the_set_when_it_was_the_last(tmp_path, monkeypatch):
+    """A card file with no draft data beside it is not a set anyone can use,
+    and nothing can rebuild from it."""
+    monkeypatch.setenv("SPELLS_DATA_HOME", str(tmp_path))
+    d = _write_set(tmp_path, "TST", EventType.PREMIER)
+
+    assert external._remove_event_type("TST", EventType.PREMIER) == 0
+    assert not d.exists()
+
+
+def test_remove_event_type_reports_a_set_it_does_not_have(tmp_path, monkeypatch):
+    monkeypatch.setenv("SPELLS_DATA_HOME", str(tmp_path))
+
+    assert external._remove_event_type("NOPE", EventType.PREMIER) == 1
+
+
+def test_remove_event_type_reports_an_event_type_it_does_not_have(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("SPELLS_DATA_HOME", str(tmp_path))
+    d = _write_set(tmp_path, "TST", EventType.PREMIER)
+
+    assert external._remove_event_type("TST", EventType.TRADITIONAL) == 1
+    assert d.exists()  # nothing touched

--- a/tests/wizard_test.py
+++ b/tests/wizard_test.py
@@ -193,7 +193,7 @@ def test_menu_offers_only_what_applies(data_home, no_network, cat):
 
     keys = [a.key for a in wizard._menu(inv, cat, wizard._check(inv, cat))]
     # nothing dead to repair and no cache yet, so neither is offered
-    assert keys == ["download", "remove", "summon", "quit"]
+    assert keys == ["download", "remove", "summon", "status", "quit"]
 
 
 def test_menu_offers_cleanup_when_there_are_dead_files(data_home, no_network, cat):
@@ -750,3 +750,38 @@ def test_the_shipped_script_ignores_sets_with_nothing_downloaded(data_home):
     module = real_runpy.run_path(str(wizard.EXAMPLE), run_name="not_main")
 
     assert list(module["event_types_by_set"](inventory.scan())) == ["REAL"]
+
+
+def test_status_can_be_shown_again_from_the_menu(data_home, no_network, cat):
+    """A download scrolls the opening screen away, and the menu alone does not
+    say what is already here."""
+    write_set(data_home, "TST")
+    inv = inventory.scan()
+
+    assert "status" in [a.key for a in wizard._menu(inv, cat, wizard._check(inv, cat))]
+
+
+def test_showing_status_again_needs_no_second_check(
+    data_home, no_network, cat, monkeypatch, capsys
+):
+    """The loop already re-checked after the last action, so redrawing must not
+    go back to the network."""
+    write_set(data_home, "TST")
+    inv = inventory.scan()
+    rows = wizard._check(inv, cat)
+
+    monkeypatch.setattr(
+        wizard, "_check", lambda *a: pytest.fail("re-checked when redrawing")
+    )
+    wizard.show_status(inv, cat, rows)
+
+    out = capsys.readouterr().out
+    assert "TST" in out
+    assert "spells status" in out
+
+
+def test_showing_status_on_an_empty_home_explains_itself(
+    data_home, no_network, cat, capsys
+):
+    wizard.show_status(inventory.scan(), cat, [])
+    assert "No 17Lands data yet" in capsys.readouterr().out

--- a/tests/wizard_test.py
+++ b/tests/wizard_test.py
@@ -484,27 +484,35 @@ def test_escape_leaves_the_remove_list(data_home, answers, no_network, cat, remo
     assert removals == []
 
 
-def test_back_and_quit_are_bound_on_every_prompt():
-    """questionary binds ctrl-c but has no key for backing out or quitting.
+@pytest.mark.parametrize(
+    "build",
+    [
+        pytest.param(lambda: questionary.confirm("x"), id="confirm"),
+        pytest.param(lambda: questionary.select("x", choices=["a"]), id="select"),
+        pytest.param(lambda: questionary.checkbox("x", choices=["a"]), id="checkbox"),
+    ],
+)
+def test_back_and_quit_bind_to_every_real_prompt(build):
+    """Against real questionary objects, not a stand-in.
 
-    Eager, like its own `a` and `i`: a plain letter needs no disambiguation.
+    `confirm` is built on a PromptSession, which hands the application bindings
+    already merged with its own — an object with no `.add`. Binding by appending
+    raised AttributeError on every confirmation in the walkthrough, and a fake
+    prompt carrying a plain KeyBindings did not notice.
     """
-    from prompt_toolkit.key_binding import KeyBindings
+    prompt = build()
+    wizard._bind_keys(prompt)
 
-    class FakeApp:
-        key_bindings = KeyBindings()
+    keys = {k for b in prompt.application.key_bindings.bindings for k in b.keys}
+    assert {wizard.BACK_KEY, wizard.QUIT_KEY} <= keys
 
-    class FakePrompt:
-        application = FakeApp()
 
+def test_binding_tolerates_a_prompt_with_no_application():
+    class Bare:
         def ask(self):
             return "answered"
 
-    assert wizard._ask(FakePrompt()) == "answered"
-
-    bound = {k for b in FakeApp.key_bindings.bindings for k in b.keys}
-    assert {wizard.BACK_KEY, wizard.QUIT_KEY} <= bound
-    assert all(b.eager() for b in FakeApp.key_bindings.bindings)
+    assert wizard._ask(Bare()) == "answered"
 
 
 def test_quitting_from_a_nested_prompt_leaves_the_walkthrough(
@@ -546,3 +554,82 @@ def test_pick_prompts_name_the_keys_questionary_cannot(
 
     assert instructions
     assert all(i and "<b> back" in i and "<q> quit" in i for i in instructions)
+
+
+# ---------------------------------------------------------------------------
+# Removing one event type
+# ---------------------------------------------------------------------------
+
+
+def test_remove_asks_which_event_types_when_several_are_held(
+    data_home, answers, no_network, cat, removals, monkeypatch
+):
+    partial = []
+    monkeypatch.setattr(
+        wizard.external,
+        "_remove_event_type",
+        lambda s, e: partial.append((s, e)) or 0,
+    )
+    write_set(data_home, "TST", EventType.PREMIER)
+    write_set(data_home, "TST", EventType.TRADITIONAL)
+    answers.extend([["TST"], [EventType.TRADITIONAL], True])
+
+    wizard.remove(inventory.scan(), cat, [])
+
+    assert partial == [("TST", EventType.TRADITIONAL)]
+    assert removals == []  # the set survives, so no whole-set removal
+
+
+def test_remove_does_not_ask_when_only_one_event_type_is_held(
+    data_home, answers, no_network, cat, removals
+):
+    write_set(data_home, "TST")
+    answers.extend([["TST"], True])
+
+    wizard.remove(inventory.scan(), cat, [])
+
+    assert answers == []  # sets, then confirm — no event-type step
+    assert removals == ["TST"]
+
+
+def test_taking_every_event_type_removes_the_whole_set(
+    data_home, answers, no_network, cat, removals, monkeypatch
+):
+    """Otherwise the card file and directory would be left behind."""
+    partial = []
+    monkeypatch.setattr(
+        wizard.external,
+        "_remove_event_type",
+        lambda s, e: partial.append((s, e)) or 0,
+    )
+    write_set(data_home, "TST", EventType.PREMIER)
+    write_set(data_home, "TST", EventType.TRADITIONAL)
+    answers.extend([["TST"], [EventType.PREMIER, EventType.TRADITIONAL], True])
+
+    wizard.remove(inventory.scan(), cat, [])
+
+    assert removals == ["TST"]
+    assert partial == []
+
+
+def test_removal_size_counts_only_the_chosen_event_types(data_home, no_network, cat):
+    write_set(data_home, "TST", EventType.PREMIER)
+    write_set(data_home, "TST", EventType.TRADITIONAL)
+    inv = inventory.scan()
+
+    one = wizard._removal_size(inv, "TST", [EventType.TRADITIONAL])
+    both = wizard._removal_size(inv, "TST", [EventType.PREMIER, EventType.TRADITIONAL])
+
+    assert 0 < one < both
+    assert both == inv.sets["TST"].total_bytes  # card file included when all goes
+
+
+def test_backing_out_of_the_event_type_step_removes_nothing(
+    data_home, answers, no_network, cat, removals
+):
+    write_set(data_home, "TST", EventType.PREMIER)
+    write_set(data_home, "TST", EventType.TRADITIONAL)
+    answers.extend([["TST"], None])
+
+    wizard.remove(inventory.scan(), cat, [])
+    assert removals == []

--- a/tests/wizard_test.py
+++ b/tests/wizard_test.py
@@ -484,13 +484,12 @@ def test_escape_leaves_the_remove_list(data_home, answers, no_network, cat, remo
     assert removals == []
 
 
-def test_escape_is_bound_on_every_prompt(monkeypatch):
-    """questionary binds ctrl-c but not escape, so the walkthrough adds it.
+def test_back_and_quit_are_bound_on_every_prompt():
+    """questionary binds ctrl-c but has no key for backing out or quitting.
 
-    Not eagerly: escape is also the first byte of an arrow-key sequence.
+    Eager, like its own `a` and `i`: a plain letter needs no disambiguation.
     """
     from prompt_toolkit.key_binding import KeyBindings
-    from prompt_toolkit.keys import Keys
 
     class FakeApp:
         key_bindings = KeyBindings()
@@ -501,21 +500,42 @@ def test_escape_is_bound_on_every_prompt(monkeypatch):
         def ask(self):
             return "answered"
 
-    prompt = FakePrompt()
-    assert wizard._ask(prompt) == "answered"
+    assert wizard._ask(FakePrompt()) == "answered"
 
-    bound = [b for b in FakeApp.key_bindings.bindings if Keys.Escape in b.keys]
-    assert bound
-    assert not any(b.eager() for b in bound)
+    bound = {k for b in FakeApp.key_bindings.bindings for k in b.keys}
+    assert {wizard.BACK_KEY, wizard.QUIT_KEY} <= bound
+    assert all(b.eager() for b in FakeApp.key_bindings.bindings)
 
 
-def test_prompts_say_escape_goes_back(data_home, no_network, cat, monkeypatch):
-    """Escape is invisible unless the prompt says so."""
-    messages = []
+def test_quitting_from_a_nested_prompt_leaves_the_walkthrough(
+    data_home, monkeypatch, no_network, cat, downloads
+):
+    """Quitting three prompts deep must not need every step in between to
+    recognize and forward it."""
+    write_set(data_home, "TST")
+
+    def quit_immediately(prompt):
+        raise wizard.Quit
+
+    monkeypatch.setattr(wizard, "_ask", quit_immediately)
+
+    wizard.run()  # returns rather than propagating
+    assert downloads == []
+
+
+def test_pick_prompts_name_the_keys_questionary_cannot(
+    data_home, no_network, cat, monkeypatch
+):
+    """`b` and `q` are invisible unless the instruction says so, and
+    questionary's own line cannot mention keys it does not know about."""
+    instructions = []
     monkeypatch.setattr(
         questionary,
         "checkbox",
-        lambda message, choices, **kw: messages.append(message) or None,
+        lambda message, choices, instruction=None, **kw: instructions.append(
+            instruction
+        )
+        or None,
     )
     monkeypatch.setattr(wizard, "_ask", lambda p: None)
 
@@ -524,83 +544,5 @@ def test_prompts_say_escape_goes_back(data_home, no_network, cat, monkeypatch):
     wizard.download(inv, cat, wizard._check(inv, cat))
     wizard.remove(inv, cat, [])
 
-    assert messages and all("esc" in m for m in messages)
-
-
-# ---------------------------------------------------------------------------
-# Derived cache
-# ---------------------------------------------------------------------------
-
-
-def write_cache(home, set_code, files=3):
-    d = home / "cache" / set_code
-    d.mkdir(parents=True, exist_ok=True)
-    for i in range(files):
-        (d / f"{i}.parquet").write_bytes(b"x" * 100)
-    return d
-
-
-def test_menu_offers_clearing_the_cache_when_there_is_one(data_home, no_network, cat):
-    write_set(data_home, "TST")
-    write_cache(data_home, "TST")
-
-    inv = inventory.scan()
-    keys = [a.key for a in wizard._menu(inv, cat, wizard._check(inv, cat))]
-    assert "cache" in keys
-
-
-def test_menu_omits_the_cache_option_when_there_is_none(data_home, no_network, cat):
-    write_set(data_home, "TST")
-
-    inv = inventory.scan()
-    keys = [a.key for a in wizard._menu(inv, cat, wizard._check(inv, cat))]
-    assert "cache" not in keys
-
-
-def test_clearing_the_cache_removes_every_set_at_once(
-    data_home, answers, no_network, cat
-):
-    """No per-set choice: derived results rebuild on demand, so the only
-    question is whether to reclaim the space."""
-    write_set(data_home, "TST")
-    write_set(data_home, "TS2")
-    write_cache(data_home, "TST")
-    write_cache(data_home, "TS2")
-    answers.append(True)
-
-    wizard.clear_cache(inventory.scan(), cat, [])
-
-    assert not (data_home / "cache" / "TST").exists()
-    assert not (data_home / "cache" / "TS2").exists()
-
-
-def test_declining_leaves_the_cache_alone(data_home, answers, no_network, cat):
-    write_set(data_home, "TST")
-    cached = write_cache(data_home, "TST")
-    answers.append(False)
-
-    wizard.clear_cache(inventory.scan(), cat, [])
-    assert cached.exists()
-
-
-def test_clearing_the_cache_never_touches_downloaded_data(
-    data_home, answers, no_network, cat
-):
-    external_dir = write_set(data_home, "TST")
-    write_cache(data_home, "TST")
-    answers.append(True)
-
-    wizard.clear_cache(inventory.scan(), cat, [])
-
-    assert sorted(p.name for p in external_dir.iterdir())
-
-
-def test_clearing_the_cache_prints_the_equivalent_command(
-    data_home, answers, no_network, cat, capsys
-):
-    write_set(data_home, "TST")
-    write_cache(data_home, "TST")
-    answers.append(True)
-
-    wizard.clear_cache(inventory.scan(), cat, [])
-    assert "spells clean all" in capsys.readouterr().out
+    assert instructions
+    assert all(i and "<b> back" in i and "<q> quit" in i for i in instructions)

--- a/tests/wizard_test.py
+++ b/tests/wizard_test.py
@@ -722,9 +722,9 @@ def test_a_failing_query_does_not_take_the_walkthrough_down(
     assert "polars said no" in capsys.readouterr().err
 
 
-def test_the_shipped_script_groups_sets_by_their_own_event_types(data_home):
-    """`summon` takes the product of the sets and event types it is given, so
-    one call naming every event type fails the read for a set missing one."""
+def test_the_shipped_script_maps_each_set_to_its_own_event_types(data_home):
+    """One flat list would ask every set for every event type, and asking for
+    one a set does not have fails the read."""
     import runpy as real_runpy
 
     write_set(data_home, "ONE", EventType.PREMIER)
@@ -732,11 +732,11 @@ def test_the_shipped_script_groups_sets_by_their_own_event_types(data_home):
     write_set(data_home, "TWO", EventType.TRADITIONAL)
 
     module = real_runpy.run_path(str(wizard.EXAMPLE), run_name="not_main")
-    groups = module["by_event_types"](inventory.scan())
+    by_set = module["event_types_by_set"](inventory.scan())
 
-    assert groups == {
-        (EventType.PREMIER,): ["ONE"],
-        (EventType.PREMIER, EventType.TRADITIONAL): ["TWO"],
+    assert by_set == {
+        "ONE": [EventType.PREMIER],
+        "TWO": [EventType.PREMIER, EventType.TRADITIONAL],
     }
 
 
@@ -748,6 +748,5 @@ def test_the_shipped_script_ignores_sets_with_nothing_downloaded(data_home):
     write_set(data_home, "REAL", EventType.PREMIER)
 
     module = real_runpy.run_path(str(wizard.EXAMPLE), run_name="not_main")
-    groups = module["by_event_types"](inventory.scan())
 
-    assert list(groups.values()) == [["REAL"]]
+    assert list(module["event_types_by_set"](inventory.scan())) == ["REAL"]

--- a/tests/wizard_test.py
+++ b/tests/wizard_test.py
@@ -1,0 +1,265 @@
+"""
+Tests for the interactive walkthrough.
+
+`_ask` is the single place questionary is called, so stubbing it drives every
+flow without a terminal. Nothing here reaches the network or downloads.
+"""
+
+import datetime
+
+import pytest
+
+from spells import catalog, external, inventory, wizard
+from spells.catalog import Catalog, Dataset
+from spells.enums import EventType
+
+LEGACY_SNAPSHOT = "PremierDraft_all_any_2026-06-23_2026-06-24.json"
+VALID_SNAPSHOT = "PremierDraft_all_any_ALL_TIME_2026-07-14.json"
+
+
+def _dataset(expansion, event_type, updated=datetime.date(2026, 7, 26)):
+    stub = f"https://example/{{}}_data_public.{expansion}.{event_type}.csv.gz"
+    return Dataset(
+        expansion=expansion,
+        format_name=str(event_type),
+        event_type=event_type,
+        last_updated=updated,
+        draft_url=stub.format("draft"),
+        game_url=stub.format("game"),
+    )
+
+
+@pytest.fixture
+def cat():
+    return Catalog(
+        datasets=(
+            _dataset("OLD", EventType.PREMIER, datetime.date(2024, 1, 1)),
+            _dataset("TST", EventType.PREMIER),
+            _dataset("TST", EventType.TRADITIONAL),
+            _dataset("NEW", EventType.PREMIER, datetime.date(2026, 8, 1)),
+        )
+    )
+
+
+@pytest.fixture
+def data_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("SPELLS_DATA_HOME", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture
+def answers(monkeypatch):
+    """Queue replies for each prompt, in order."""
+    queued = []
+
+    def fake_ask(prompt):
+        return queued.pop(0) if queued else None
+
+    monkeypatch.setattr(wizard, "_ask", fake_ask)
+    return queued
+
+
+@pytest.fixture
+def no_network(monkeypatch, cat):
+    monkeypatch.setattr(catalog, "fetch", lambda *a, **k: cat)
+    monkeypatch.setattr(wizard.catalog, "fetch", lambda *a, **k: cat)
+    monkeypatch.setattr(wizard.catalog, "head", lambda url: None)
+    monkeypatch.setattr(catalog, "head", lambda url: None)
+
+
+@pytest.fixture
+def downloads(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        external, "_add", lambda s, event_type, **kw: calls.append((s, event_type)) or 0
+    )
+    monkeypatch.setattr(
+        wizard.external,
+        "_add",
+        lambda s, event_type, **kw: calls.append((s, event_type)) or 0,
+    )
+    return calls
+
+
+def write_set(home, set_code, event_type=EventType.PREMIER):
+    d = home / "external" / set_code
+    d.mkdir(parents=True, exist_ok=True)
+    for view in ("draft", "game", "context"):
+        (d / f"{set_code}_{event_type}_{view}.parquet").write_bytes(b"x" * 10)
+    (d / f"{set_code}_card.parquet").write_bytes(b"x" * 10)
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Bootstrapping
+# ---------------------------------------------------------------------------
+
+
+def test_empty_data_home_goes_straight_to_adding(
+    data_home, answers, no_network, downloads
+):
+    """A first run has exactly one useful action, so no menu is shown."""
+    answers.extend(["NEW", True])  # set, then confirm the download
+
+    wizard.run()
+
+    assert downloads == [("NEW", EventType.PREMIER)]
+
+
+def test_bootstrap_picks_the_only_event_type_without_asking(
+    data_home, answers, no_network, downloads
+):
+    """NEW publishes one event type; asking would be a prompt with one answer."""
+    answers.extend(["NEW", True])
+
+    wizard.run()
+
+    assert downloads == [("NEW", EventType.PREMIER)]
+    assert answers == []  # both replies consumed: set and confirm, nothing else
+
+
+def test_bootstrap_asks_for_event_type_when_several_are_published(
+    data_home, answers, no_network, downloads
+):
+    answers.extend(["TST", EventType.TRADITIONAL, True])
+
+    wizard.run()
+
+    assert downloads == [("TST", EventType.TRADITIONAL)]
+
+
+def test_declining_the_download_adds_nothing(data_home, answers, no_network, downloads):
+    answers.extend(["NEW", False])
+
+    wizard.run()
+
+    assert downloads == []
+
+
+def test_backing_out_of_the_set_list_adds_nothing(
+    data_home, answers, no_network, downloads
+):
+    answers.append(wizard.CANCEL)
+
+    wizard.run()
+
+    assert downloads == []
+
+
+# ---------------------------------------------------------------------------
+# The menu
+# ---------------------------------------------------------------------------
+
+
+def test_menu_offers_only_what_the_data_home_needs(data_home, no_network, cat):
+    write_set(data_home, "TST")
+    inv = inventory.scan()
+
+    keys = [a.key for a in wizard._menu(inv, cat)]
+
+    # nothing stale and nothing to clean, so neither is offered as a chore
+    assert "update" not in keys
+    assert "clean" not in keys
+    assert keys[0] == "add"
+    assert keys[-1] == "quit"
+
+
+def test_menu_offers_cleanup_when_there_are_dead_files(data_home, no_network, cat):
+    write_set(data_home, "TST")
+    snaps = data_home / "ratings" / "TST"
+    snaps.mkdir(parents=True)
+    (snaps / LEGACY_SNAPSHOT).write_text("[]")
+    (snaps / VALID_SNAPSHOT).write_text("[]")
+
+    keys = [a.key for a in wizard._menu(inventory.scan(), cat)]
+    assert "clean" in keys
+
+
+def test_menu_counts_sets_you_could_add(data_home, no_network, cat):
+    write_set(data_home, "TST")
+
+    actions = {a.key: a.detail for a in wizard._menu(inventory.scan(), cat)}
+    assert "1" in actions["add"]  # NEW is published and absent; OLD predates TST
+
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_free_space_deletes_only_after_confirmation(
+    data_home, answers, no_network, cat
+):
+    write_set(data_home, "TST")
+    snaps = data_home / "ratings" / "TST"
+    snaps.mkdir(parents=True)
+    (snaps / LEGACY_SNAPSHOT).write_text("[]")
+    (snaps / VALID_SNAPSHOT).write_text("[]")
+
+    answers.append(False)
+    wizard.free_space(inventory.scan(), cat)
+    assert (snaps / LEGACY_SNAPSHOT).exists()
+
+    answers.append(True)
+    wizard.free_space(inventory.scan(), cat)
+    assert not (snaps / LEGACY_SNAPSHOT).exists()
+    assert (snaps / VALID_SNAPSHOT).exists()
+
+
+def test_free_space_leaves_advisories_alone(data_home, answers, no_network, cat):
+    """An unrecognized directory is reported, never deleted — same rule doctor
+    follows."""
+    write_set(data_home, "TST")
+    (data_home / "mystery").mkdir()
+    (data_home / "mystery" / "notes.txt").write_bytes(b"x")
+
+    answers.append(True)
+    wizard.free_space(inventory.scan(), cat)
+
+    assert (data_home / "mystery").exists()
+
+
+# ---------------------------------------------------------------------------
+# Commands are taught, not hidden
+# ---------------------------------------------------------------------------
+
+
+def test_actions_print_the_equivalent_command(
+    data_home, answers, no_network, downloads, capsys
+):
+    answers.extend(["NEW", True])
+    wizard.run()
+
+    assert "spells add NEW PremierDraft" in capsys.readouterr().out
+
+
+def test_cleanup_prints_the_equivalent_command(
+    data_home, answers, no_network, cat, capsys
+):
+    write_set(data_home, "TST")
+    snaps = data_home / "ratings" / "TST"
+    snaps.mkdir(parents=True)
+    (snaps / LEGACY_SNAPSHOT).write_text("[]")
+
+    answers.append(True)
+    wizard.free_space(inventory.scan(), cat)
+
+    assert "spells doctor --yes" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Offline
+# ---------------------------------------------------------------------------
+
+
+def test_unreachable_catalog_still_allows_local_actions(
+    data_home, answers, monkeypatch, capsys
+):
+    write_set(data_home, "TST")
+    fallback = Catalog(datasets=(), is_fallback=True)
+    monkeypatch.setattr(wizard.catalog, "fetch", lambda *a, **k: fallback)
+    answers.append("quit")
+
+    wizard.run()
+
+    assert "Could not reach 17Lands" in capsys.readouterr().err

--- a/tests/wizard_test.py
+++ b/tests/wizard_test.py
@@ -453,68 +453,78 @@ def test_a_pre_selected_set_is_labelled_by_reason(data_home, no_network, cat):
 # ---------------------------------------------------------------------------
 
 
-def test_backing_out_of_the_download_list_downloads_nothing(
+def test_escape_leaves_the_download_list(
     data_home, answers, no_network, cat, downloads
 ):
+    """`_ask` returns None on escape, the same as ctrl-c."""
     write_set(data_home, "TST")
     inv = inventory.scan()
-    answers.append([wizard.BACK])
+    answers.append(None)
 
     wizard.download(inv, cat, wizard._check(inv, cat))
     assert downloads == []
 
 
-def test_backing_out_wins_over_anything_else_ticked(
-    data_home, answers, no_network, cat, downloads
-):
-    """Someone who selected it meant to leave, whatever the cursor passed over."""
-    write_set(data_home, "TST")
-    inv = inventory.scan()
-    answers.append([wizard.BACK, "NEW"])
-
-    wizard.download(inv, cat, wizard._check(inv, cat))
-    assert downloads == []
-
-
-def test_backing_out_of_the_event_type_step_downloads_nothing(
+def test_escape_leaves_the_event_type_step(
     data_home, answers, no_network, cat, downloads
 ):
     write_set(data_home, "TST", mtime=OLDER)
     inv = inventory.scan()
-    answers.extend([["TST"], [wizard.BACK]])
+    answers.extend([["TST"], None])
 
     wizard.download(inv, cat, wizard._check(inv, cat))
     assert downloads == []
 
 
-def test_backing_out_of_the_remove_list_deletes_nothing(
-    data_home, answers, no_network, cat, removals
-):
+def test_escape_leaves_the_remove_list(data_home, answers, no_network, cat, removals):
     write_set(data_home, "TST")
-    answers.append([wizard.BACK])
+    answers.append(None)
 
     wizard.remove(inventory.scan(), cat, [])
     assert removals == []
 
 
-def test_every_multi_select_offers_a_way_out(data_home, no_network, cat, monkeypatch):
-    """Backing out has to be visible in the list, not folklore about pressing
-    enter on an empty selection."""
-    write_set(data_home, "TST", mtime=OLDER)
-    seen = []
+def test_escape_is_bound_on_every_prompt(monkeypatch):
+    """questionary binds ctrl-c but not escape, so the walkthrough adds it.
 
+    Not eagerly: escape is also the first byte of an arrow-key sequence.
+    """
+    from prompt_toolkit.key_binding import KeyBindings
+    from prompt_toolkit.keys import Keys
+
+    class FakeApp:
+        key_bindings = KeyBindings()
+
+    class FakePrompt:
+        application = FakeApp()
+
+        def ask(self):
+            return "answered"
+
+    prompt = FakePrompt()
+    assert wizard._ask(prompt) == "answered"
+
+    bound = [b for b in FakeApp.key_bindings.bindings if Keys.Escape in b.keys]
+    assert bound
+    assert not any(b.eager() for b in bound)
+
+
+def test_prompts_say_escape_goes_back(data_home, no_network, cat, monkeypatch):
+    """Escape is invisible unless the prompt says so."""
+    messages = []
     monkeypatch.setattr(
         questionary,
         "checkbox",
-        lambda message, choices, **kw: seen.append([c.value for c in choices]) or None,
+        lambda message, choices, **kw: messages.append(message) or None,
     )
     monkeypatch.setattr(wizard, "_ask", lambda p: None)
 
+    write_set(data_home, "TST", mtime=OLDER)
     inv = inventory.scan()
     wizard.download(inv, cat, wizard._check(inv, cat))
     wizard.remove(inv, cat, [])
 
-    assert seen and all(wizard.BACK in choices for choices in seen)
+    assert messages and all("esc" in m for m in messages)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/wizard_test.py
+++ b/tests/wizard_test.py
@@ -192,7 +192,8 @@ def test_menu_offers_only_what_applies(data_home, no_network, cat):
     inv = inventory.scan()
 
     keys = [a.key for a in wizard._menu(inv, cat, wizard._check(inv, cat))]
-    assert keys == ["download", "remove", "quit"]  # nothing dead, no cache yet
+    # nothing dead to repair and no cache yet, so neither is offered
+    assert keys == ["download", "remove", "summon", "quit"]
 
 
 def test_menu_offers_cleanup_when_there_are_dead_files(data_home, no_network, cat):
@@ -633,3 +634,102 @@ def test_backing_out_of_the_event_type_step_removes_nothing(
 
     wizard.remove(inventory.scan(), cat, [])
     assert removals == []
+
+
+# ---------------------------------------------------------------------------
+# The example query
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def ran(monkeypatch):
+    """Stand in for the script: the fake data home has no readable parquet."""
+    calls = []
+    monkeypatch.setattr(wizard.runpy, "run_path", lambda p, **kw: calls.append(p) or {})
+    return calls
+
+
+@pytest.fixture
+def elsewhere(tmp_path, monkeypatch):
+    cwd = tmp_path / "somewhere"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+    return cwd
+
+
+def test_example_query_needs_data_first(data_home, answers, no_network, cat, ran):
+    wizard.try_summon(inventory.scan(), cat, [])
+    assert ran == []
+
+
+def test_example_query_runs_the_shipped_script(
+    data_home, answers, no_network, cat, ran, elsewhere
+):
+    write_set(data_home, "TST")
+    answers.append(False)
+
+    wizard.try_summon(inventory.scan(), cat, [])
+
+    assert ran == [str(wizard.EXAMPLE)]
+
+
+def test_declining_leaves_the_working_directory_alone(
+    data_home, answers, no_network, cat, ran, elsewhere
+):
+    write_set(data_home, "TST")
+    answers.append(False)
+
+    wizard.try_summon(inventory.scan(), cat, [])
+    assert list(elsewhere.iterdir()) == []
+
+
+def test_accepting_copies_the_script_next_to_you(
+    data_home, answers, no_network, cat, ran, elsewhere
+):
+    write_set(data_home, "TST")
+    answers.append(True)
+
+    wizard.try_summon(inventory.scan(), cat, [])
+
+    copied = elsewhere / wizard.EXAMPLE.name
+    assert copied.exists()
+    assert copied.read_text() == wizard.EXAMPLE.read_text()
+
+
+def test_copying_over_an_existing_file_says_so(
+    data_home, answers, no_network, cat, ran, elsewhere, capsys
+):
+    write_set(data_home, "TST")
+    (elsewhere / wizard.EXAMPLE.name).write_text("mine")
+    answers.append(False)
+
+    wizard.try_summon(inventory.scan(), cat, [])
+
+    assert (elsewhere / wizard.EXAMPLE.name).read_text() == "mine"
+
+
+def test_a_failing_query_does_not_take_the_walkthrough_down(
+    data_home, answers, no_network, cat, monkeypatch, elsewhere, capsys
+):
+    write_set(data_home, "TST")
+
+    def boom(path, **kw):
+        raise RuntimeError("polars said no")
+
+    monkeypatch.setattr(wizard.runpy, "run_path", boom)
+
+    wizard.try_summon(inventory.scan(), cat, [])  # returns rather than raising
+    assert "polars said no" in capsys.readouterr().err
+
+
+def test_the_shipped_script_only_names_installed_event_types(data_home):
+    """Naming an event type with no parquet fails the read rather than
+    returning nothing for it."""
+    import runpy as real_runpy
+
+    write_set(data_home, "TST", EventType.PREMIER)
+    module = real_runpy.run_path(str(wizard.EXAMPLE), run_name="not_main")
+
+    sets, event_types = module["installed"]()
+    assert sets == ["TST"]
+    assert event_types == [EventType.PREMIER]

--- a/tests/wizard_test.py
+++ b/tests/wizard_test.py
@@ -6,15 +6,22 @@ flow without a terminal. Nothing here reaches the network or downloads.
 """
 
 import datetime
+import os
+import pathlib
 
 import pytest
 
-from spells import catalog, external, inventory, wizard
-from spells.catalog import Catalog, Dataset
+from spells import catalog, inventory, wizard
+from spells.catalog import Catalog, Dataset, RemoteFile
 from spells.enums import EventType
 
 LEGACY_SNAPSHOT = "PremierDraft_all_any_2026-06-23_2026-06-24.json"
 VALID_SNAPSHOT = "PremierDraft_all_any_ALL_TIME_2026-07-14.json"
+
+UTC = datetime.timezone.utc
+REMOTE_TIME = datetime.datetime(2026, 7, 27, tzinfo=UTC)
+OLDER = datetime.datetime(2026, 1, 1, tzinfo=UTC).timestamp()
+NEWER = datetime.datetime(2026, 8, 5, tzinfo=UTC).timestamp()
 
 
 def _dataset(expansion, event_type, updated=datetime.date(2026, 7, 26)):
@@ -31,6 +38,7 @@ def _dataset(expansion, event_type, updated=datetime.date(2026, 7, 26)):
 
 @pytest.fixture
 def cat():
+    """OLD predates the collection, TST is held, NEW is published after it."""
     return Catalog(
         datasets=(
             _dataset("OLD", EventType.PREMIER, datetime.date(2024, 1, 1)),
@@ -51,28 +59,23 @@ def data_home(tmp_path, monkeypatch):
 def answers(monkeypatch):
     """Queue replies for each prompt, in order."""
     queued = []
-
-    def fake_ask(prompt):
-        return queued.pop(0) if queued else None
-
-    monkeypatch.setattr(wizard, "_ask", fake_ask)
+    monkeypatch.setattr(wizard, "_ask", lambda p: queued.pop(0) if queued else None)
     return queued
 
 
 @pytest.fixture
 def no_network(monkeypatch, cat):
-    monkeypatch.setattr(catalog, "fetch", lambda *a, **k: cat)
+    def remote(url):
+        return RemoteFile(url=url, last_modified=REMOTE_TIME)
+
     monkeypatch.setattr(wizard.catalog, "fetch", lambda *a, **k: cat)
-    monkeypatch.setattr(wizard.catalog, "head", lambda url: None)
-    monkeypatch.setattr(catalog, "head", lambda url: None)
+    monkeypatch.setattr(wizard.catalog, "head", remote)
+    monkeypatch.setattr(catalog, "head", remote)
 
 
 @pytest.fixture
 def downloads(monkeypatch):
     calls = []
-    monkeypatch.setattr(
-        external, "_add", lambda s, event_type, **kw: calls.append((s, event_type)) or 0
-    )
     monkeypatch.setattr(
         wizard.external,
         "_add",
@@ -81,69 +84,100 @@ def downloads(monkeypatch):
     return calls
 
 
-def write_set(home, set_code, event_type=EventType.PREMIER):
+@pytest.fixture
+def removals(monkeypatch):
+    calls = []
+    monkeypatch.setattr(wizard.external, "_remove", lambda s: calls.append(s) or 0)
+    return calls
+
+
+def write_set(home, set_code, event_type=EventType.PREMIER, mtime=NEWER):
     d = home / "external" / set_code
     d.mkdir(parents=True, exist_ok=True)
     for view in ("draft", "game", "context"):
-        (d / f"{set_code}_{event_type}_{view}.parquet").write_bytes(b"x" * 10)
+        path = d / f"{set_code}_{event_type}_{view}.parquet"
+        path.write_bytes(b"x" * 10)
+        os.utime(path, (mtime, mtime))
     (d / f"{set_code}_card.parquet").write_bytes(b"x" * 10)
     return d
 
 
+def offers_for(inv, cat):
+    return wizard.candidates(inv, cat, wizard._check(inv, cat))
+
+
 # ---------------------------------------------------------------------------
-# Bootstrapping
+# What gets offered, and what is ticked
 # ---------------------------------------------------------------------------
 
 
-def test_empty_data_home_goes_straight_to_adding(
-    data_home, answers, no_network, downloads
-):
-    """A first run has exactly one useful action, so no menu is shown."""
-    answers.extend(["NEW", True])  # set, then confirm the download
+def test_a_first_run_pre_selects_the_two_newest_sets(cat):
+    """Enough to start without knowing which codes are current, and far short
+    of the tens of gigabytes that ticking everything would queue."""
+    empty = inventory.Inventory(data_home=pathlib.Path("/tmp/nothing-here"))
 
-    wizard.run()
+    ticked = [c for c in wizard.candidates(empty, cat, []) if c.wanted]
 
-    assert downloads == [("NEW", EventType.PREMIER)]
-
-
-def test_bootstrap_picks_the_only_event_type_without_asking(
-    data_home, answers, no_network, downloads
-):
-    """NEW publishes one event type; asking would be a prompt with one answer."""
-    answers.extend(["NEW", True])
-
-    wizard.run()
-
-    assert downloads == [("NEW", EventType.PREMIER)]
-    assert answers == []  # both replies consumed: set and confirm, nothing else
+    assert [c.expansion for c in ticked] == ["NEW", "TST"]
+    assert all(c.event_type == EventType.PREMIER for c in ticked)
 
 
-def test_bootstrap_asks_for_event_type_when_several_are_published(
-    data_home, answers, no_network, downloads
-):
-    answers.extend(["TST", EventType.TRADITIONAL, True])
+def test_a_first_run_ticks_only_premier_for_those_sets(cat):
+    """TST publishes TradDraft too; a newcomer wants one format, not both."""
+    empty = inventory.Inventory(data_home=pathlib.Path("/tmp/nothing-here"))
 
-    wizard.run()
+    offers = wizard.candidates(empty, cat, [])
+    trad = [c for c in offers if c.event_type == EventType.TRADITIONAL]
 
-    assert downloads == [("TST", EventType.TRADITIONAL)]
-
-
-def test_declining_the_download_adds_nothing(data_home, answers, no_network, downloads):
-    answers.extend(["NEW", False])
-
-    wizard.run()
-
-    assert downloads == []
+    assert trad and not any(c.wanted for c in trad)
 
 
-def test_backing_out_of_the_set_list_adds_nothing(
-    data_home, answers, no_network, downloads
-):
-    answers.append(wizard.CANCEL)
+def test_a_first_run_does_not_call_anything_new(cat):
+    """Nothing can be new to a data home with nothing in it."""
+    empty = inventory.Inventory(data_home=pathlib.Path("/tmp/nothing-here"))
 
-    wizard.run()
+    assert not any(c.reason == "new set" for c in wizard.candidates(empty, cat, []))
 
-    assert downloads == []
+
+def test_a_set_published_since_you_started_is_pre_selected(data_home, no_network, cat):
+    write_set(data_home, "TST")
+
+    new = [c for c in offers_for(inventory.scan(), cat) if c.expansion == "NEW"]
+    assert [c.reason for c in new] == ["new set"]
+    assert all(c.wanted for c in new)
+
+
+def test_a_set_predating_your_collection_is_not_offered(data_home, no_network, cat):
+    write_set(data_home, "TST")
+    assert "OLD" not in {c.expansion for c in offers_for(inventory.scan(), cat)}
+
+
+def test_stale_data_is_pre_selected(data_home, no_network, cat):
+    write_set(data_home, "TST", mtime=OLDER)
+
+    stale = [
+        c
+        for c in offers_for(inventory.scan(), cat)
+        if c.expansion == "TST" and c.reason == "update available"
+    ]
+    assert stale and all(c.wanted for c in stale)
+
+
+def test_an_event_type_you_never_wanted_is_offered_unticked(data_home, no_network, cat):
+    """TST publishes TradDraft too, but only Premier was ever downloaded."""
+    write_set(data_home, "TST")
+
+    trad = [
+        c
+        for c in offers_for(inventory.scan(), cat)
+        if c.expansion == "TST" and c.event_type == EventType.TRADITIONAL
+    ]
+    assert trad and not any(c.wanted for c in trad)
+
+
+def test_offers_are_newest_set_first(data_home, no_network, cat):
+    write_set(data_home, "TST")
+    assert offers_for(inventory.scan(), cat)[0].expansion == "NEW"
 
 
 # ---------------------------------------------------------------------------
@@ -151,17 +185,12 @@ def test_backing_out_of_the_set_list_adds_nothing(
 # ---------------------------------------------------------------------------
 
 
-def test_menu_offers_only_what_the_data_home_needs(data_home, no_network, cat):
+def test_menu_offers_only_what_applies(data_home, no_network, cat):
     write_set(data_home, "TST")
     inv = inventory.scan()
 
-    keys = [a.key for a in wizard._menu(inv, cat)]
-
-    # nothing stale and nothing to clean, so neither is offered as a chore
-    assert "update" not in keys
-    assert "clean" not in keys
-    assert keys[0] == "add"
-    assert keys[-1] == "quit"
+    keys = [a.key for a in wizard._menu(inv, cat, wizard._check(inv, cat))]
+    assert keys == ["download", "remove", "quit"]  # nothing dead to clean up
 
 
 def test_menu_offers_cleanup_when_there_are_dead_files(data_home, no_network, cat):
@@ -169,17 +198,108 @@ def test_menu_offers_cleanup_when_there_are_dead_files(data_home, no_network, ca
     snaps = data_home / "ratings" / "TST"
     snaps.mkdir(parents=True)
     (snaps / LEGACY_SNAPSHOT).write_text("[]")
-    (snaps / VALID_SNAPSHOT).write_text("[]")
 
-    keys = [a.key for a in wizard._menu(inventory.scan(), cat)]
-    assert "clean" in keys
+    inv = inventory.scan()
+    assert "clean" in [a.key for a in wizard._menu(inv, cat, wizard._check(inv, cat))]
 
 
-def test_menu_counts_sets_you_could_add(data_home, no_network, cat):
+def test_menu_has_nothing_to_remove_on_a_first_run(data_home, no_network, cat):
+    assert "remove" not in [a.key for a in wizard._menu(inventory.scan(), cat, [])]
+
+
+# ---------------------------------------------------------------------------
+# Downloading
+# ---------------------------------------------------------------------------
+
+
+def test_download_queues_the_chosen_sets(
+    data_home, answers, no_network, cat, downloads
+):
     write_set(data_home, "TST")
+    inv = inventory.scan()
+    answers.extend([["NEW"], True])
 
-    actions = {a.key: a.detail for a in wizard._menu(inventory.scan(), cat)}
-    assert "1" in actions["add"]  # NEW is published and absent; OLD predates TST
+    wizard.download(inv, cat, wizard._check(inv, cat))
+    assert downloads == [("NEW", EventType.PREMIER)]
+
+
+def test_download_asks_for_event_types_when_several_are_offered(
+    data_home, answers, no_network, cat, downloads
+):
+    write_set(data_home, "TST", mtime=OLDER)
+    inv = inventory.scan()
+    answers.extend([["TST"], [EventType.TRADITIONAL], True])
+
+    wizard.download(inv, cat, wizard._check(inv, cat))
+    assert downloads == [("TST", EventType.TRADITIONAL)]
+
+
+def test_download_skips_the_event_type_step_when_there_is_one(
+    data_home, answers, no_network, cat, downloads
+):
+    write_set(data_home, "TST")
+    inv = inventory.scan()
+    answers.extend([["NEW"], True])
+
+    wizard.download(inv, cat, wizard._check(inv, cat))
+    assert answers == []  # the confirm took the second reply, not an event step
+    assert downloads == [("NEW", EventType.PREMIER)]
+
+
+def test_selecting_no_sets_downloads_nothing(
+    data_home, answers, no_network, cat, downloads
+):
+    write_set(data_home, "TST")
+    inv = inventory.scan()
+    answers.append([])
+
+    wizard.download(inv, cat, wizard._check(inv, cat))
+    assert downloads == []
+
+
+def test_declining_the_confirmation_downloads_nothing(
+    data_home, answers, no_network, cat, downloads
+):
+    write_set(data_home, "TST")
+    inv = inventory.scan()
+    answers.extend([["NEW"], False])
+
+    wizard.download(inv, cat, wizard._check(inv, cat))
+    assert downloads == []
+
+
+# ---------------------------------------------------------------------------
+# Removing
+# ---------------------------------------------------------------------------
+
+
+def test_remove_deletes_the_chosen_sets(data_home, answers, no_network, cat, removals):
+    write_set(data_home, "TST")
+    write_set(data_home, "TS2")
+    answers.extend([["TST"], True])
+
+    wizard.remove(inventory.scan(), cat, [])
+    assert removals == ["TST"]
+
+
+def test_remove_defaults_to_declining(data_home, answers, no_network, cat, removals):
+    """Nothing is pre-ticked and the confirmation defaults to no: this is the
+    one action in the walkthrough that destroys downloaded data."""
+    write_set(data_home, "TST")
+    answers.extend([["TST"], False])
+
+    wizard.remove(inventory.scan(), cat, [])
+    assert removals == []
+
+
+def test_remove_with_nothing_selected_deletes_nothing(
+    data_home, answers, no_network, cat, removals
+):
+    write_set(data_home, "TST")
+    answers.append([])
+
+    wizard.remove(inventory.scan(), cat, [])
+    assert removals == []
 
 
 # ---------------------------------------------------------------------------
@@ -197,24 +317,24 @@ def test_free_space_deletes_only_after_confirmation(
     (snaps / VALID_SNAPSHOT).write_text("[]")
 
     answers.append(False)
-    wizard.free_space(inventory.scan(), cat)
+    wizard.free_space(inventory.scan(), cat, [])
     assert (snaps / LEGACY_SNAPSHOT).exists()
 
     answers.append(True)
-    wizard.free_space(inventory.scan(), cat)
+    wizard.free_space(inventory.scan(), cat, [])
     assert not (snaps / LEGACY_SNAPSHOT).exists()
     assert (snaps / VALID_SNAPSHOT).exists()
 
 
 def test_free_space_leaves_advisories_alone(data_home, answers, no_network, cat):
-    """An unrecognized directory is reported, never deleted — same rule doctor
+    """An unrecognized directory is reported, never deleted — the rule doctor
     follows."""
     write_set(data_home, "TST")
     (data_home / "mystery").mkdir()
     (data_home / "mystery" / "notes.txt").write_bytes(b"x")
 
     answers.append(True)
-    wizard.free_space(inventory.scan(), cat)
+    wizard.free_space(inventory.scan(), cat, [])
 
     assert (data_home / "mystery").exists()
 
@@ -224,13 +344,25 @@ def test_free_space_leaves_advisories_alone(data_home, answers, no_network, cat)
 # ---------------------------------------------------------------------------
 
 
-def test_actions_print_the_equivalent_command(
-    data_home, answers, no_network, downloads, capsys
+def test_downloading_prints_the_equivalent_command(
+    data_home, answers, no_network, cat, downloads, capsys
 ):
-    answers.extend(["NEW", True])
-    wizard.run()
+    write_set(data_home, "TST")
+    inv = inventory.scan()
+    answers.extend([["NEW"], True])
 
+    wizard.download(inv, cat, wizard._check(inv, cat))
     assert "spells add NEW PremierDraft" in capsys.readouterr().out
+
+
+def test_removing_prints_the_equivalent_command(
+    data_home, answers, no_network, cat, removals, capsys
+):
+    write_set(data_home, "TST")
+    answers.extend([["TST"], True])
+
+    wizard.remove(inventory.scan(), cat, [])
+    assert "spells remove TST --yes" in capsys.readouterr().out
 
 
 def test_cleanup_prints_the_equivalent_command(
@@ -242,24 +374,73 @@ def test_cleanup_prints_the_equivalent_command(
     (snaps / LEGACY_SNAPSHOT).write_text("[]")
 
     answers.append(True)
-    wizard.free_space(inventory.scan(), cat)
-
+    wizard.free_space(inventory.scan(), cat, [])
     assert "spells doctor --yes" in capsys.readouterr().out
 
 
 # ---------------------------------------------------------------------------
-# Offline
+# The opening screen
 # ---------------------------------------------------------------------------
 
 
-def test_unreachable_catalog_still_allows_local_actions(
-    data_home, answers, monkeypatch, capsys
+def test_opening_shows_the_status_table_when_there_is_data(
+    data_home, no_network, cat, capsys
 ):
+    write_set(data_home, "TST")
+    wizard._opening(inventory.scan(), cat)
+
+    out = capsys.readouterr().out
+    assert "TST" in out
+    assert "event types" in out
+
+
+def test_opening_explains_itself_when_there_is_no_data(
+    data_home, no_network, cat, capsys
+):
+    wizard._opening(inventory.scan(), cat)
+
+    out = capsys.readouterr().out
+    assert "No 17Lands data yet" in out
+    assert "published, not downloaded" in out
+
+
+def test_opening_names_sets_with_newer_data(data_home, no_network, cat, capsys):
+    write_set(data_home, "TST", mtime=OLDER)
+    wizard._opening(inventory.scan(), cat)
+
+    assert "have newer data" in capsys.readouterr().out
+
+
+def test_unreachable_catalog_still_allows_local_actions(data_home, monkeypatch, capsys):
     write_set(data_home, "TST")
     fallback = Catalog(datasets=(), is_fallback=True)
     monkeypatch.setattr(wizard.catalog, "fetch", lambda *a, **k: fallback)
+
+    rows = wizard._opening(inventory.scan(), fallback)
+
+    assert rows == []
+    assert "Could not reach 17Lands" in capsys.readouterr().err
+
+
+def test_quitting_leaves_immediately(data_home, answers, no_network, cat, downloads):
+    write_set(data_home, "TST")
     answers.append("quit")
 
     wizard.run()
+    assert downloads == []
 
-    assert "Could not reach 17Lands" in capsys.readouterr().err
+
+def test_a_partly_held_set_is_labelled_by_event_type(data_home, no_network, cat):
+    """ "not downloaded" beside a set you plainly have reads as though the whole
+    thing were missing, when only an event type is."""
+    write_set(data_home, "TST")
+    offers = offers_for(inventory.scan(), cat)
+
+    assert wizard._reasons_for(offers, "TST") == "TradDraft"
+
+
+def test_a_pre_selected_set_is_labelled_by_reason(data_home, no_network, cat):
+    write_set(data_home, "TST")
+    offers = offers_for(inventory.scan(), cat)
+
+    assert wizard._reasons_for(offers, "NEW") == "new set"

--- a/tests/wizard_test.py
+++ b/tests/wizard_test.py
@@ -11,6 +11,8 @@ import pathlib
 
 import pytest
 
+import questionary
+
 from spells import catalog, inventory, wizard
 from spells.catalog import Catalog, Dataset, RemoteFile
 from spells.enums import EventType
@@ -190,7 +192,7 @@ def test_menu_offers_only_what_applies(data_home, no_network, cat):
     inv = inventory.scan()
 
     keys = [a.key for a in wizard._menu(inv, cat, wizard._check(inv, cat))]
-    assert keys == ["download", "remove", "quit"]  # nothing dead to clean up
+    assert keys == ["download", "remove", "quit"]  # nothing dead, no cache yet
 
 
 def test_menu_offers_cleanup_when_there_are_dead_files(data_home, no_network, cat):
@@ -200,7 +202,7 @@ def test_menu_offers_cleanup_when_there_are_dead_files(data_home, no_network, ca
     (snaps / LEGACY_SNAPSHOT).write_text("[]")
 
     inv = inventory.scan()
-    assert "clean" in [a.key for a in wizard._menu(inv, cat, wizard._check(inv, cat))]
+    assert "repair" in [a.key for a in wizard._menu(inv, cat, wizard._check(inv, cat))]
 
 
 def test_menu_has_nothing_to_remove_on_a_first_run(data_home, no_network, cat):
@@ -444,3 +446,151 @@ def test_a_pre_selected_set_is_labelled_by_reason(data_home, no_network, cat):
     offers = offers_for(inventory.scan(), cat)
 
     assert wizard._reasons_for(offers, "NEW") == "new set"
+
+
+# ---------------------------------------------------------------------------
+# Backing out
+# ---------------------------------------------------------------------------
+
+
+def test_backing_out_of_the_download_list_downloads_nothing(
+    data_home, answers, no_network, cat, downloads
+):
+    write_set(data_home, "TST")
+    inv = inventory.scan()
+    answers.append([wizard.BACK])
+
+    wizard.download(inv, cat, wizard._check(inv, cat))
+    assert downloads == []
+
+
+def test_backing_out_wins_over_anything_else_ticked(
+    data_home, answers, no_network, cat, downloads
+):
+    """Someone who selected it meant to leave, whatever the cursor passed over."""
+    write_set(data_home, "TST")
+    inv = inventory.scan()
+    answers.append([wizard.BACK, "NEW"])
+
+    wizard.download(inv, cat, wizard._check(inv, cat))
+    assert downloads == []
+
+
+def test_backing_out_of_the_event_type_step_downloads_nothing(
+    data_home, answers, no_network, cat, downloads
+):
+    write_set(data_home, "TST", mtime=OLDER)
+    inv = inventory.scan()
+    answers.extend([["TST"], [wizard.BACK]])
+
+    wizard.download(inv, cat, wizard._check(inv, cat))
+    assert downloads == []
+
+
+def test_backing_out_of_the_remove_list_deletes_nothing(
+    data_home, answers, no_network, cat, removals
+):
+    write_set(data_home, "TST")
+    answers.append([wizard.BACK])
+
+    wizard.remove(inventory.scan(), cat, [])
+    assert removals == []
+
+
+def test_every_multi_select_offers_a_way_out(data_home, no_network, cat, monkeypatch):
+    """Backing out has to be visible in the list, not folklore about pressing
+    enter on an empty selection."""
+    write_set(data_home, "TST", mtime=OLDER)
+    seen = []
+
+    monkeypatch.setattr(
+        questionary,
+        "checkbox",
+        lambda message, choices, **kw: seen.append([c.value for c in choices]) or None,
+    )
+    monkeypatch.setattr(wizard, "_ask", lambda p: None)
+
+    inv = inventory.scan()
+    wizard.download(inv, cat, wizard._check(inv, cat))
+    wizard.remove(inv, cat, [])
+
+    assert seen and all(wizard.BACK in choices for choices in seen)
+
+
+# ---------------------------------------------------------------------------
+# Derived cache
+# ---------------------------------------------------------------------------
+
+
+def write_cache(home, set_code, files=3):
+    d = home / "cache" / set_code
+    d.mkdir(parents=True, exist_ok=True)
+    for i in range(files):
+        (d / f"{i}.parquet").write_bytes(b"x" * 100)
+    return d
+
+
+def test_menu_offers_clearing_the_cache_when_there_is_one(data_home, no_network, cat):
+    write_set(data_home, "TST")
+    write_cache(data_home, "TST")
+
+    inv = inventory.scan()
+    keys = [a.key for a in wizard._menu(inv, cat, wizard._check(inv, cat))]
+    assert "cache" in keys
+
+
+def test_menu_omits_the_cache_option_when_there_is_none(data_home, no_network, cat):
+    write_set(data_home, "TST")
+
+    inv = inventory.scan()
+    keys = [a.key for a in wizard._menu(inv, cat, wizard._check(inv, cat))]
+    assert "cache" not in keys
+
+
+def test_clearing_the_cache_removes_every_set_at_once(
+    data_home, answers, no_network, cat
+):
+    """No per-set choice: derived results rebuild on demand, so the only
+    question is whether to reclaim the space."""
+    write_set(data_home, "TST")
+    write_set(data_home, "TS2")
+    write_cache(data_home, "TST")
+    write_cache(data_home, "TS2")
+    answers.append(True)
+
+    wizard.clear_cache(inventory.scan(), cat, [])
+
+    assert not (data_home / "cache" / "TST").exists()
+    assert not (data_home / "cache" / "TS2").exists()
+
+
+def test_declining_leaves_the_cache_alone(data_home, answers, no_network, cat):
+    write_set(data_home, "TST")
+    cached = write_cache(data_home, "TST")
+    answers.append(False)
+
+    wizard.clear_cache(inventory.scan(), cat, [])
+    assert cached.exists()
+
+
+def test_clearing_the_cache_never_touches_downloaded_data(
+    data_home, answers, no_network, cat
+):
+    external_dir = write_set(data_home, "TST")
+    write_cache(data_home, "TST")
+    answers.append(True)
+
+    wizard.clear_cache(inventory.scan(), cat, [])
+
+    assert sorted(p.name for p in external_dir.iterdir())
+
+
+def test_clearing_the_cache_prints_the_equivalent_command(
+    data_home, answers, no_network, cat, capsys
+):
+    write_set(data_home, "TST")
+    write_cache(data_home, "TST")
+    answers.append(True)
+
+    wizard.clear_cache(inventory.scan(), cat, [])
+    assert "spells clean all" in capsys.readouterr().out

--- a/tests/wizard_test.py
+++ b/tests/wizard_test.py
@@ -722,14 +722,32 @@ def test_a_failing_query_does_not_take_the_walkthrough_down(
     assert "polars said no" in capsys.readouterr().err
 
 
-def test_the_shipped_script_only_names_installed_event_types(data_home):
-    """Naming an event type with no parquet fails the read rather than
-    returning nothing for it."""
+def test_the_shipped_script_groups_sets_by_their_own_event_types(data_home):
+    """`summon` takes the product of the sets and event types it is given, so
+    one call naming every event type fails the read for a set missing one."""
     import runpy as real_runpy
 
-    write_set(data_home, "TST", EventType.PREMIER)
-    module = real_runpy.run_path(str(wizard.EXAMPLE), run_name="not_main")
+    write_set(data_home, "ONE", EventType.PREMIER)
+    write_set(data_home, "TWO", EventType.PREMIER)
+    write_set(data_home, "TWO", EventType.TRADITIONAL)
 
-    sets, event_types = module["installed"]()
-    assert sets == ["TST"]
-    assert event_types == [EventType.PREMIER]
+    module = real_runpy.run_path(str(wizard.EXAMPLE), run_name="not_main")
+    groups = module["by_event_types"](inventory.scan())
+
+    assert groups == {
+        (EventType.PREMIER,): ["ONE"],
+        (EventType.PREMIER, EventType.TRADITIONAL): ["TWO"],
+    }
+
+
+def test_the_shipped_script_ignores_sets_with_nothing_downloaded(data_home):
+    import runpy as real_runpy
+
+    (data_home / "ratings" / "GHOST").mkdir(parents=True)
+    (data_home / "ratings" / "GHOST" / LEGACY_SNAPSHOT).write_text("[]")
+    write_set(data_home, "REAL", EventType.PREMIER)
+
+    module = real_runpy.run_path(str(wizard.EXAMPLE), run_name="not_main")
+    groups = module["by_event_types"](inventory.scan())
+
+    assert list(groups.values()) == [["REAL"]]


### PR DESCRIPTION
The wizard. No `manage` command — bare `spells` *is* the walkthrough, per your call.

## New user, empty data home

There is exactly one useful thing to do, so it skips the menu:

```
  No 17Lands data here yet.
      spells keeps draft and game datasets under this directory,
      then answers questions about them with `summon`.

   Which set? (Use arrow keys)
 » MSH             2026-07-26
   SOS             2026-06-02
   TMT             2026-04-08
   ...
   ... 22 older sets
   Back
```

Newest first (catalog release order), 12 shown so a newcomer isn't reading a wall of expansions they've never heard of. Event type is only asked when a set publishes more than one — asking otherwise is a prompt with one answer. Then it HEADs for the real download size before confirming, and finishes by naming the three commands worth knowing.

## Returning user

The menu is built from what the data home **actually needs**. On the real 7 GB data home right now:

```
   What would you like to do? (Use arrow keys)
 » Add a set                 2 published, not downloaded
   Show what I have
   Quit
```

No "update" (nothing stale) and no "free up space" (already cleaned). A set that's current is never presented as a chore. When there *is* something dead:

```
   Free up space             195.4MiB unusable
```

## Every action prints its command

```
  $ spells status
  1 set(s), 11.0B in /tmp/olduser
      TST             PremierDraft
```

So the walkthrough teaches its way out of being needed, rather than hiding the verbs.

## Headless

Piped, redirected, or under cron, bare `spells` still prints the status report — a prompt there would either hang or be drawn where nobody is reading. `spells | less` is unchanged, and so is anything in `publish.sh`. `--quiet` also forces the report.

## Scope

Nothing here does work the flat commands cannot; it's a front end over `inventory`, `catalog`, `repair`, and `external`. Deletion goes through `repair.plan`/`apply`, so advisory anomalies (an unrecognized directory) are reported and never removed — same rule `doctor` follows, asserted by a test.

`sizeof_fmt` moves from `cli` to `console` so both reach it without one importing the other. That was prompted by the wizard reporting `0 MB unusable` for a 3-byte file.

## Dependency

`questionary>=2.1` — one transitive dep (prompt_toolkit), last released 2025-08-28. Agreed earlier when we picked it over textual.

Also fixes `scripts/post_install.py`, which still imported the `spells_print` removed in #34 and broke `pdm install`. It wasn't caught because it lives outside `spells/`.

## Testing

**262 passing**, ruff clean. 13 new: bootstrap goes straight to adding, the single-event-type case doesn't prompt, declining or backing out downloads nothing, the menu omits what isn't needed and counts what is, cleanup only deletes after confirmation and never touches advisories, and both actions print their equivalent command. `_ask` is the only place questionary is called, so stubbing it drives every flow without a terminal.

Beyond the unit tests I drove the real binary through a pty to confirm it actually renders and that the menu loop and Ctrl-C exit behave — the screenshots above are from that.