### PR TITLE
Let each set choose its own event types

### DIFF
--- a/spells/draft_data.py
+++ b/spells/draft_data.py
@@ -485,6 +485,51 @@ def _base_agg_df(
     return joined_df
 
 
+# one event type for every set, several for every set, or a different choice
+# per set
+EventTypeSpec = (
+    EventType
+    | str
+    | list[EventType | str]
+    | dict[str, "EventType | str | list[EventType | str]"]
+)
+
+
+def _event_type_cells(
+    event_type: EventTypeSpec, codes: list[str]
+) -> list[tuple[str, EventType]]:
+    """Which (set, event type) pairs to aggregate.
+
+    One value or list applies to every set, which is the product this has
+    always taken. A dict gives each set its own, for a collection where the
+    sets are not all held in the same formats — asking for one a set does not
+    have is an error rather than an empty result, so the product is only right
+    when every set has every event type named.
+
+    A dict must name every set asked for: defaulting the rest to Premier would
+    turn a mistyped set code into a silently different query.
+    """
+    if isinstance(event_type, dict):
+        if missing := [code for code in codes if code not in event_type]:
+            raise ValueError(
+                f"No event type given for {', '.join(sorted(missing))}. Name "
+                "every set in the dict, or pass one value to use for all."
+            )
+        per_code = {code: event_type[code] for code in codes}
+    else:
+        per_code = {code: event_type for code in codes}
+
+    cells = []
+    for code in codes:
+        chosen = per_code[code]
+        chosen = chosen if isinstance(chosen, list) else [chosen]
+        if not chosen:
+            raise ValueError(f"No event type given for {code}")
+        # dict.fromkeys rather than set: cell order drives the frame order
+        cells.extend((code, et) for et in dict.fromkeys(EventType(e) for e in chosen))
+    return cells
+
+
 def _normalize_context_keys(
     context: pl.DataFrame | dict | Any | None,
     cells: list[tuple[str, EventType]],
@@ -555,7 +600,7 @@ def summon(
     write_cache: bool = True,
     card_context: pl.DataFrame | dict | None = None,
     set_context: pl.DataFrame | dict | None = None,
-    event_type: EventType | list[EventType] = EventType.PREMIER,
+    event_type: EventTypeSpec = EventType.PREMIER,
 ) -> pl.DataFrame:
     specs = get_specs()
 
@@ -569,62 +614,57 @@ def summon(
 
     assert codes, "Please ask for at least one set"
 
-    event_types = event_type if isinstance(event_type, list) else [event_type]
-    event_types = [EventType(et) for et in event_types]
-
-    cells = [(code, et) for code in codes for et in event_types]
+    cells = _event_type_cells(event_type, codes)
     card_context_by_cell = _normalize_context_keys(card_context, cells)
     set_context_by_cell = _normalize_context_keys(set_context, cells)
 
     m = None
 
     concat_dfs = []
-    for code in codes:
-        for code_event_type in event_types:
-            cell = (code, code_event_type)
+    for cell in cells:
+        code, code_event_type = cell
+        logging.info(f"Calculating agg df for {code} {code_event_type}")
+        col_def_map = _hydrate_col_defs(
+            code,
+            specs,
+            card_context_by_cell[cell],
+            set_context_by_cell[cell],
+            code_event_type,
+        )
+        m = manifest.create(col_def_map, columns, group_by, filter_spec)
 
-            logging.info(f"Calculating agg df for {code} {code_event_type}")
-            col_def_map = _hydrate_col_defs(
+        calc_fn = functools.partial(
+            _base_agg_df,
+            code,
+            m,
+            code_event_type,
+            use_streaming=use_streaming,
+        )
+        agg_df = _fetch_or_cache(
+            calc_fn,
+            code,
+            (
                 code,
-                specs,
-                card_context_by_cell[cell],
-                set_context_by_cell[cell],
-                code_event_type,
+                code_event_type.value,
+                sorted(m.view_cols.get(View.DRAFT, set())),
+                sorted(m.view_cols.get(View.GAME, set())),
+                sorted(c.signature or "" for c in m.col_def_map.values()),
+                sorted(m.base_view_group_by),
+                filter_spec,
+            ),
+            read_cache=read_cache,
+            write_cache=write_cache,
+        )
+        if View.CARD in m.view_cols:
+            card_cols = m.view_cols[View.CARD].union({ColName.NAME})
+            fp = cache.data_file_path(code, View.CARD)
+            card_df = pl.read_parquet(fp)
+            select_df = _view_select(
+                card_df, card_cols, m.col_def_map, is_agg_view=False
             )
-            m = manifest.create(col_def_map, columns, group_by, filter_spec)
+            agg_df = agg_df.join(select_df, on="name", how="full", coalesce=True)
 
-            calc_fn = functools.partial(
-                _base_agg_df,
-                code,
-                m,
-                code_event_type,
-                use_streaming=use_streaming,
-            )
-            agg_df = _fetch_or_cache(
-                calc_fn,
-                code,
-                (
-                    code,
-                    code_event_type.value,
-                    sorted(m.view_cols.get(View.DRAFT, set())),
-                    sorted(m.view_cols.get(View.GAME, set())),
-                    sorted(c.signature or "" for c in m.col_def_map.values()),
-                    sorted(m.base_view_group_by),
-                    filter_spec,
-                ),
-                read_cache=read_cache,
-                write_cache=write_cache,
-            )
-            if View.CARD in m.view_cols:
-                card_cols = m.view_cols[View.CARD].union({ColName.NAME})
-                fp = cache.data_file_path(code, View.CARD)
-                card_df = pl.read_parquet(fp)
-                select_df = _view_select(
-                    card_df, card_cols, m.col_def_map, is_agg_view=False
-                )
-                agg_df = agg_df.join(select_df, on="name", how="full", coalesce=True)
-
-            concat_dfs.append(agg_df)
+        concat_dfs.append(agg_df)
 
     assert (
         m is not None
@@ -636,7 +676,7 @@ def summon(
 @make_verbose()
 def card_ratings_view(
     set_code: str | list[str],
-    event_type: EventType | list[EventType] = EventType.PREMIER,
+    event_type: EventTypeSpec = EventType.PREMIER,
     player_cohort: str = "all",
     deck_colors: str | list[str] = "any",
     time_period: TimePeriod = TimePeriod.ALL_TIME,
@@ -671,37 +711,35 @@ def card_ratings_view(
 
     assert codes, "Please ask for at least one set"
 
-    event_types = event_type if isinstance(event_type, list) else [event_type]
-    event_types = [EventType(et) for et in event_types]
+    cells = _event_type_cells(event_type, codes)
 
     time_period = TimePeriod(time_period)
 
     m = None
 
     concat_dfs = []
-    for code in codes:
-        for code_event_type in event_types:
-            agg_df = base_ratings_df(
-                set_code=code,
-                event_type=code_event_type,
-                player_cohort=player_cohort,
-                deck_colors=deck_colors,
-                time_period=time_period,
-                cache_usage=cache_usage,
-            )
-            names = agg_df[ColName.NAME].to_list()
+    for code, code_event_type in cells:
+        agg_df = base_ratings_df(
+            set_code=code,
+            event_type=code_event_type,
+            player_cohort=player_cohort,
+            deck_colors=deck_colors,
+            time_period=time_period,
+            cache_usage=cache_usage,
+        )
+        names = agg_df[ColName.NAME].to_list()
 
-            col_def_map = _hydrate_col_defs(
-                code,
-                specs,
-                None,
-                None,
-                code_event_type,
-                card_only=True,
-                names=names,
-            )
-            m = manifest.create(col_def_map, columns, group_by, None)
-            concat_dfs.append(agg_df)
+        col_def_map = _hydrate_col_defs(
+            code,
+            specs,
+            None,
+            None,
+            code_event_type,
+            card_only=True,
+            names=names,
+        )
+        m = manifest.create(col_def_map, columns, group_by, None)
+        concat_dfs.append(agg_df)
 
     assert (
         m is not None

--- a/tests/event_type_cells_test.py
+++ b/tests/event_type_cells_test.py
@@ -1,0 +1,99 @@
+"""
+Tests for choosing which (set, event type) pairs a query covers.
+
+The product of every set and every event type is only right when every set
+holds every one of them. A collection where it does not — some sets Premier
+only, one also Traditional, one Pick Two — makes the product ask for files that
+were never downloaded, which fails the read rather than returning nothing for
+those pairs.
+"""
+
+import pytest
+
+from spells.draft_data import _event_type_cells
+from spells.enums import EventType
+
+PREMIER = EventType.PREMIER
+TRAD = EventType.TRADITIONAL
+PICK_TWO = EventType.PICK_TWO
+
+
+def test_one_event_type_applies_to_every_set():
+    assert _event_type_cells(PREMIER, ["AAA", "BBB"]) == [
+        ("AAA", PREMIER),
+        ("BBB", PREMIER),
+    ]
+
+
+def test_a_list_applies_to_every_set():
+    assert _event_type_cells([PREMIER, TRAD], ["AAA", "BBB"]) == [
+        ("AAA", PREMIER),
+        ("AAA", TRAD),
+        ("BBB", PREMIER),
+        ("BBB", TRAD),
+    ]
+
+
+def test_a_dict_gives_each_set_its_own():
+    cells = _event_type_cells(
+        {"AAA": PREMIER, "BBB": [PREMIER, TRAD], "CCC": PICK_TWO},
+        ["AAA", "BBB", "CCC"],
+    )
+
+    assert cells == [
+        ("AAA", PREMIER),
+        ("BBB", PREMIER),
+        ("BBB", TRAD),
+        ("CCC", PICK_TWO),
+    ]
+
+
+def test_a_dict_asks_for_nothing_a_set_does_not_have():
+    """The point of the mapping: no (BBB, PickTwoDraft) pair to fail on."""
+    cells = _event_type_cells(
+        {"AAA": [PREMIER, PICK_TWO], "BBB": PREMIER}, ["AAA", "BBB"]
+    )
+
+    assert ("BBB", PICK_TWO) not in cells
+    assert ("AAA", PICK_TWO) in cells
+
+
+def test_strings_are_accepted_like_every_other_enum_argument():
+    assert _event_type_cells({"AAA": "PremierDraft"}, ["AAA"]) == [("AAA", PREMIER)]
+    assert _event_type_cells("TradDraft", ["AAA"]) == [("AAA", TRAD)]
+
+
+def test_cell_order_follows_the_sets_asked_for():
+    """Cell order drives the order of the concatenated frames."""
+    cells = _event_type_cells({"BBB": PREMIER, "AAA": PREMIER}, ["BBB", "AAA"])
+    assert [code for code, _ in cells] == ["BBB", "AAA"]
+
+
+def test_repeats_within_one_set_collapse():
+    assert _event_type_cells({"AAA": [PREMIER, PREMIER]}, ["AAA"]) == [("AAA", PREMIER)]
+
+
+def test_a_dict_must_name_every_set():
+    """Defaulting the rest would turn a mistyped set code into a silently
+    different query rather than an error."""
+    with pytest.raises(ValueError, match="BBB"):
+        _event_type_cells({"AAA": PREMIER}, ["AAA", "BBB"])
+
+
+def test_extra_keys_are_ignored_so_one_mapping_serves_many_queries():
+    assert _event_type_cells({"AAA": PREMIER, "ZZZ": TRAD}, ["AAA"]) == [
+        ("AAA", PREMIER)
+    ]
+
+
+def test_an_empty_choice_is_an_error_not_an_empty_frame():
+    with pytest.raises(ValueError, match="AAA"):
+        _event_type_cells({"AAA": []}, ["AAA"])
+
+    with pytest.raises(ValueError, match="AAA"):
+        _event_type_cells([], ["AAA"])
+
+
+def test_an_unknown_event_type_still_raises():
+    with pytest.raises(ValueError):
+        _event_type_cells({"AAA": "NotADraft"}, ["AAA"])


### PR DESCRIPTION
Branched off `main` — this is the `summon` API, independent of the CLI work in #35.

## The problem

`event_type` applied one choice to every set, so `summon` took the product:

```python
cells = [(code, et) for code in codes for et in event_types]   # draft_data.py:575
```

That's only right when every set is held in every format named. Otherwise it asks for a file that was never downloaded:

```
FileNotFoundError: .../BLB/BLB_PickTwoDraft_draft.parquet
```

The full-product assumption held while a collection meant one set, or several downloaded alike. A real one doesn't:

```
  23 set(s): PremierDraft
   4 set(s): PremierDraft, TradDraft
   1 set(s): PickTwoDraft, PremierDraft, TradDraft
   1 set(s): PickTwoDraft
```

Four combinations across 29 sets, so covering the whole collection took one call per combination plus a concatenate.

## The change

`event_type` now also takes a dict of set to event types — the same shape `card_context` and `set_context` already accept, so the three read alike:

```python
summon(
    sorted(event_types),
    columns=[ColName.NUM_TAKEN, ColName.NUM_GAMES],
    group_by=[ColName.EXPANSION, ColName.EVENT_TYPE],
    event_type={"MSH": [PREMIER, TRAD, PICK_TWO], "BLB": PREMIER, ...},
)
```

Verified against the real 29-set collection: **one call, 36 rows, 22 seconds**, identical to what the four-call workaround produced.

`card_ratings_view` gets it too. An absent pair there returns an empty response rather than a missing file, but it's the same wrong question, and the two are counterparts.

## Decisions worth reviewing

**A dict must name every set asked for.** Defaulting the rest to Premier would turn a mistyped set code into a silently different query rather than an error. Extra keys *are* ignored, so one mapping can serve several queries.

**Asking for nothing raises** rather than returning an empty frame — `{"AAA": []}` and `[]` are both errors.

**Cell order follows the sets asked for**, since it drives the order of the concatenated frames. Repeats within a set collapse via `dict.fromkeys` rather than a set, to keep that order.

## Testing

**260 passing**, ruff clean. 11 new in `event_type_cells_test.py`: the two existing broadcast forms still behave, a dict gives each set its own, no pair is produced for a set that lacks it, strings work like every other enum argument, order is preserved, repeats collapse, and each error case raises rather than quietly returning less.

Nothing about the existing forms changed — a bare value and a list still produce exactly the product they always did.