### PR TITLE
Count both picks of a pick-two row

### DIFF
--- a/spells/columns.py
+++ b/spells/columns.py
@@ -190,7 +190,8 @@ _specs: dict[str, ColSpec] = {
     ColName.NUM_DRAFTS: ColSpec(
         col_type=ColType.PICK_SUM,
         expr=pl.when(
-            (pl.col(ColName.PACK_NUMBER) == 0)
+            (pl.col(ColName.PICK_ORDINAL) == 1)
+            & (pl.col(ColName.PACK_NUMBER) == 0)
             & (
                 pl.col(ColName.PICK_NUMBER)
                 == pl.when(pl.col(ColName.EXPANSION).is_in(P1P1_MISSING_SETS))
@@ -207,6 +208,14 @@ _specs: dict[str, ColSpec] = {
     ),
     ColName.PICK_2: ColSpec(
         col_type=ColType.FILTER_ONLY,
+        views=[View.DRAFT],
+    ),
+    ColName.PICK_ORDINAL: ColSpec(
+        # 1 everywhere except the second pick of a pick-two row, so a column
+        # that only holds for the first can say which it means. Grouping by it
+        # separates the card a drafter reached for from the one they took
+        # alongside it — the two are not interchangeable.
+        col_type=ColType.GROUP_BY,
         views=[View.DRAFT],
     ),
     ColName.PICK_MAINDECK_RATE: ColSpec(

--- a/spells/draft_data.py
+++ b/spells/draft_data.py
@@ -30,6 +30,14 @@ from spells.card_data_files import base_ratings_df, CacheUsage
 
 DF = TypeVar("DF", pl.LazyFrame, pl.DataFrame)
 
+# measured against the first pick of a row and published without a counterpart
+# for the second, so they describe only that card
+FIRST_PICK_ONLY = (ColName.PICK_MAINDECK_RATE, ColName.PICK_SIDEBOARD_IN_RATE)
+
+# bumped when the meaning of a pick-two aggregate changes, since the column
+# definitions can stay identical while every total moves
+PICK_TWO_AGG_VERSION = 2
+
 
 def _cache_key(args) -> str:
     """
@@ -391,6 +399,52 @@ def _fetch_or_cache(
     return df
 
 
+def _pick_events(
+    draft_df: pl.LazyFrame, view: View, event_type: EventType
+) -> pl.LazyFrame:
+    """The draft view as one row per pick rather than per pick row.
+
+    A pick-two row records two picks, so it becomes two rows: the second is the
+    same row with `pick_2` standing in as `pick`. Doing this on the raw frame,
+    before any column expression is evaluated, means every expression written
+    against `pick` counts both without knowing there were two.
+
+    `pick_ordinal` says which of the two a row is, so a column that only holds
+    for the first can say so — `num_drafts` counts drafts rather than cards,
+    and 17Lands computes the maindeck rates from the first pick alone.
+    """
+    first = _with_pick_ordinal(draft_df, view)
+    if view != View.DRAFT or event_type != EventType.PICK_TWO:
+        return first
+
+    second = draft_df.drop(ColName.PICK).rename({ColName.PICK_2: ColName.PICK})
+    second = second.with_columns(
+        pl.lit(2, dtype=pl.Int8).alias(ColName.PICK_ORDINAL),
+        # 17Lands derives these from the first pick and publishes no
+        # counterpart for the second, so they are absent here rather than
+        # describing the wrong card. Should a `pick_2_` counterpart appear,
+        # rename it in beside `pick` instead of nulling.
+        *(
+            pl.lit(None, dtype=pl.Float64).alias(col)
+            for col in FIRST_PICK_ONLY
+            if col in draft_df.collect_schema().names()
+        ),
+    )
+    return pl.concat([first.drop(ColName.PICK_2), second], how="vertical_relaxed")
+
+
+def _with_pick_ordinal(draft_df: pl.LazyFrame, view: View) -> pl.LazyFrame:
+    """Make `pick_ordinal` available without splitting any row.
+
+    A row-level view keeps one row per pick row, with `pick_2` beside `pick`,
+    so the row is always the first pick. The column still has to resolve there:
+    the same definitions serve both that view and the aggregation.
+    """
+    if view != View.DRAFT:
+        return draft_df
+    return draft_df.with_columns(pl.lit(1, dtype=pl.Int8).alias(ColName.PICK_ORDINAL))
+
+
 def _base_agg_df(
     set_code: str,
     m: manifest.Manifest,
@@ -407,7 +461,7 @@ def _base_agg_df(
         if view == View.CARD:
             continue
         df_path = cache.data_file_path(set_code, view, event_type)
-        base_view_df = pl.scan_parquet(df_path)
+        base_view_df = _pick_events(pl.scan_parquet(df_path), view, event_type)
         base_df_prefilter = _view_select(
             base_view_df, cols_for_view, m.col_def_map, is_agg_view=False
         )
@@ -651,6 +705,14 @@ def summon(
                 sorted(c.signature or "" for c in m.col_def_map.values()),
                 sorted(m.base_view_group_by),
                 filter_spec,
+                # counting both picks changed every pick-two total without
+                # changing a column definition, so anything cached under the
+                # old meaning has to miss
+                *(
+                    (PICK_TWO_AGG_VERSION,)
+                    if code_event_type == EventType.PICK_TWO
+                    else ()
+                ),
             ),
             read_cache=read_cache,
             write_cache=write_cache,
@@ -777,7 +839,7 @@ def lazy_select(
     )
 
     df_path = cache.data_file_path(set_code, view, event_type)
-    base_view_df = pl.scan_parquet(df_path)
+    base_view_df = _with_pick_ordinal(pl.scan_parquet(df_path), view)
 
     select_cols = frozenset(columns)
 

--- a/spells/draft_data.py
+++ b/spells/draft_data.py
@@ -34,6 +34,9 @@ DF = TypeVar("DF", pl.LazyFrame, pl.DataFrame)
 # for the second, so they describe only that card
 FIRST_PICK_ONLY = (ColName.PICK_MAINDECK_RATE, ColName.PICK_SIDEBOARD_IN_RATE)
 
+# every draft row is a first pick until a pick-two row is split into two
+PICK_ORDINAL_FIRST = pl.lit(1, dtype=pl.Int8).alias(ColName.PICK_ORDINAL)
+
 # bumped when the meaning of a pick-two aggregate changes, since the column
 # definitions can stay identical while every total moves
 PICK_TWO_AGG_VERSION = 2
@@ -413,7 +416,7 @@ def _pick_events(
     for the first can say so — `num_drafts` counts drafts rather than cards,
     and 17Lands computes the maindeck rates from the first pick alone.
     """
-    first = _with_pick_ordinal(draft_df, view)
+    first = draft_df.with_columns(PICK_ORDINAL_FIRST)
     if view != View.DRAFT or event_type != EventType.PICK_TWO:
         return first
 
@@ -431,18 +434,6 @@ def _pick_events(
         ),
     )
     return pl.concat([first.drop(ColName.PICK_2), second], how="vertical_relaxed")
-
-
-def _with_pick_ordinal(draft_df: pl.LazyFrame, view: View) -> pl.LazyFrame:
-    """Make `pick_ordinal` available without splitting any row.
-
-    A row-level view keeps one row per pick row, with `pick_2` beside `pick`,
-    so the row is always the first pick. The column still has to resolve there:
-    the same definitions serve both that view and the aggregation.
-    """
-    if view != View.DRAFT:
-        return draft_df
-    return draft_df.with_columns(pl.lit(1, dtype=pl.Int8).alias(ColName.PICK_ORDINAL))
 
 
 def _base_agg_df(
@@ -839,7 +830,7 @@ def lazy_select(
     )
 
     df_path = cache.data_file_path(set_code, view, event_type)
-    base_view_df = _with_pick_ordinal(pl.scan_parquet(df_path), view)
+    base_view_df = pl.scan_parquet(df_path).with_columns(PICK_ORDINAL_FIRST)
 
     select_cols = frozenset(columns)
 

--- a/spells/enums.py
+++ b/spells/enums.py
@@ -82,6 +82,7 @@ class ColName(StrEnum):
     NUM_DRAFTS = "num_drafts"
     PICK = "pick"
     PICK_2 = "pick_2"  # PickTwoDraft only
+    PICK_ORDINAL = "pick_ordinal"  # 1, or 2 for the second of a pick-two pick
     PICK_MAINDECK_RATE = "pick_maindeck_rate"
     PICK_SIDEBOARD_IN_RATE = "pick_sideboard_in_rate"
     PACK_CARD = "pack_card"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -151,6 +151,7 @@ def _make_draft_row(
     event_match_wins=0,
     event_match_losses=0,
     event_type=EventType.PREMIER,
+    pick_2=None,
 ):
     """One pick row. All cards are present in the pack; one is picked."""
     row = {
@@ -169,6 +170,8 @@ def _make_draft_row(
         "user_n_games_bucket": user_n_games_bucket,
         "user_game_win_rate_bucket": user_game_win_rate_bucket,
     }
+    if pick_2 is not None:
+        row["pick_2"] = pick_2
     for name in FAKE_CARD_NAMES:
         row[f"pack_card_{name}"] = 1
         row[f"pool_{name}"] = 0
@@ -240,7 +243,7 @@ def _make_game_row(
     return row
 
 
-def _draft_schema():
+def _draft_schema(pick_two=False):
     return {
         "expansion": pl.String,
         "event_type": pl.String,
@@ -252,6 +255,7 @@ def _draft_schema():
         "pack_number": pl.Int8,
         "pick_number": pl.Int8,
         "pick": pl.String,
+        **({"pick_2": pl.String} if pick_two else {}),
         "pick_maindeck_rate": pl.Float64,
         "pick_sideboard_in_rate": pl.Float64,
         "user_n_games_bucket": pl.Int16,
@@ -319,7 +323,8 @@ def _write_set_parquets(
         }
     ).write_parquet(set_dir / f"{set_code}_{event_type}_context.parquet")
 
-    pl.DataFrame(draft_rows, schema=_draft_schema()).write_parquet(
+    pick_two = "pick_2" in draft_rows[0]
+    pl.DataFrame(draft_rows, schema=_draft_schema(pick_two)).write_parquet(
         set_dir / f"{set_code}_{event_type}_draft.parquet"
     )
 
@@ -754,6 +759,45 @@ def fake_trad_set(
     )
 
     yield tmp_path
+
+
+PICK_TWO_ROW_COUNT = 3
+
+
+@pytest.fixture()
+def fake_pick_two(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Generator[int, None, None]:
+    """Writes set TST with both Premier and pick-two draft parquets.
+
+    The pick-two file is one draft over PICK_TWO_ROW_COUNT rows, each naming a
+    different card in `pick` and `pick_2`, so the two picks stay tellable apart.
+    Yields the row count: picks are twice that, drafts are one.
+    """
+    monkeypatch.setenv("SPELLS_DATA_HOME", str(tmp_path))
+    ext = tmp_path / "external"
+
+    _write_set_parquets(ext, FAKE_SET, _tst_draft_rows(), _tst_game_rows())
+    _write_set_parquets(
+        ext, FAKE_SET, _tst_pick_two_draft_rows(), event_type=EventType.PICK_TWO
+    )
+
+    yield PICK_TWO_ROW_COUNT
+
+
+def _tst_pick_two_draft_rows():
+    return [
+        _make_draft_row(
+            FAKE_SET,
+            "x001",
+            0,
+            pick_number,
+            FAKE_CARD_NAMES[2 * pick_number],
+            pick_2=FAKE_CARD_NAMES[2 * pick_number + 1],
+            event_type=EventType.PICK_TWO,
+        )
+        for pick_number in range(PICK_TWO_ROW_COUNT)
+    ]
 
 
 @pytest.fixture()

--- a/tests/pick_two_test.py
+++ b/tests/pick_two_test.py
@@ -11,7 +11,7 @@ import polars as pl
 import pytest
 
 from spells import summon
-from spells.draft_data import _pick_events, _with_pick_ordinal
+from spells.draft_data import PICK_ORDINAL_FIRST, _pick_events
 from spells.enums import ColName, EventType, View
 
 PREMIER = EventType.PREMIER
@@ -63,11 +63,13 @@ def test_a_single_pick_row_stays_one_event(rows):
     assert out[ColName.PICK_ORDINAL].to_list() == [1, 1]
 
 
-def test_the_game_view_is_untouched():
+def test_the_game_view_is_never_split():
+    """It carries the ordinal too, which costs nothing because a view only ever
+    selects the columns asked of it — but a game is one row however it drafted."""
     game = pl.LazyFrame({"draft_id": ["a"], "won": [1]})
-    assert _pick_events(game, View.GAME, PICK_TWO).collect().to_dicts() == [
-        {"draft_id": "a", "won": 1}
-    ]
+    out = _pick_events(game, View.GAME, PICK_TWO).collect()
+
+    assert out[["draft_id", "won"]].to_dicts() == [{"draft_id": "a", "won": 1}]
 
 
 def test_first_pick_only_columns_are_absent_from_the_second_event(rows):
@@ -90,7 +92,7 @@ def test_first_pick_only_columns_survive_on_the_first_event(rows):
 def test_a_row_level_view_keeps_one_row_and_both_picks(rows):
     """`lazy_select` reconstructs drafts, so it must not split anything — but
     the column still has to resolve, since one set of definitions serves both."""
-    out = _with_pick_ordinal(rows, View.DRAFT).collect()
+    out = rows.with_columns(PICK_ORDINAL_FIRST).collect()
 
     assert len(out) == 2
     assert ColName.PICK_2 in out.columns

--- a/tests/pick_two_test.py
+++ b/tests/pick_two_test.py
@@ -1,0 +1,153 @@
+"""
+Tests for counting both picks of a pick-two row.
+
+A pick-two row records two picks, so aggregating it as one understated every
+per-pick total by half. The draft view becomes one row per pick, and
+`pick_ordinal` says which of the two a row is, for the columns where that
+matters.
+"""
+
+import polars as pl
+import pytest
+
+from spells import summon
+from spells.draft_data import _pick_events, _with_pick_ordinal
+from spells.enums import ColName, EventType, View
+
+PREMIER = EventType.PREMIER
+PICK_TWO = EventType.PICK_TWO
+
+
+@pytest.fixture
+def rows() -> pl.LazyFrame:
+    return pl.LazyFrame(
+        {
+            ColName.PICK: ["Alpha", "Gamma"],
+            ColName.PICK_2: ["Beta", "Delta"],
+            ColName.PICK_MAINDECK_RATE: [1.0, 0.5],
+            ColName.PICK_SIDEBOARD_IN_RATE: [0.25, 0.75],
+            ColName.PACK_NUMBER: [0, 0],
+            ColName.PICK_NUMBER: [0, 1],
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# The projection
+# ---------------------------------------------------------------------------
+
+
+def test_a_pick_two_row_becomes_two_pick_events(rows):
+    out = _pick_events(rows, View.DRAFT, PICK_TWO).collect()
+
+    assert len(out) == 4
+    assert out[ColName.PICK].to_list() == ["Alpha", "Gamma", "Beta", "Delta"]
+
+
+def test_the_second_pick_stands_in_as_the_pick(rows):
+    """Renaming on the raw frame is what lets every expression written against
+    `pick` count both without knowing there were two."""
+    out = _pick_events(rows, View.DRAFT, PICK_TWO).collect()
+
+    assert ColName.PICK_2 not in out.columns
+    assert out.filter(pl.col(ColName.PICK_ORDINAL) == 2)[ColName.PICK].to_list() == [
+        "Beta",
+        "Delta",
+    ]
+
+
+def test_a_single_pick_row_stays_one_event(rows):
+    out = _pick_events(rows, View.DRAFT, PREMIER).collect()
+
+    assert len(out) == 2
+    assert out[ColName.PICK_ORDINAL].to_list() == [1, 1]
+
+
+def test_the_game_view_is_untouched():
+    game = pl.LazyFrame({"draft_id": ["a"], "won": [1]})
+    assert _pick_events(game, View.GAME, PICK_TWO).collect().to_dicts() == [
+        {"draft_id": "a", "won": 1}
+    ]
+
+
+def test_first_pick_only_columns_are_absent_from_the_second_event(rows):
+    """17Lands derives both rates from the first pick and publishes no
+    counterpart, so carrying them over would describe the wrong card."""
+    out = _pick_events(rows, View.DRAFT, PICK_TWO).collect()
+    second = out.filter(pl.col(ColName.PICK_ORDINAL) == 2)
+
+    assert second[ColName.PICK_MAINDECK_RATE].to_list() == [None, None]
+    assert second[ColName.PICK_SIDEBOARD_IN_RATE].to_list() == [None, None]
+
+
+def test_first_pick_only_columns_survive_on_the_first_event(rows):
+    out = _pick_events(rows, View.DRAFT, PICK_TWO).collect()
+    first = out.filter(pl.col(ColName.PICK_ORDINAL) == 1)
+
+    assert first[ColName.PICK_MAINDECK_RATE].to_list() == [1.0, 0.5]
+
+
+def test_a_row_level_view_keeps_one_row_and_both_picks(rows):
+    """`lazy_select` reconstructs drafts, so it must not split anything — but
+    the column still has to resolve, since one set of definitions serves both."""
+    out = _with_pick_ordinal(rows, View.DRAFT).collect()
+
+    assert len(out) == 2
+    assert ColName.PICK_2 in out.columns
+    assert out[ColName.PICK_ORDINAL].to_list() == [1, 1]
+
+
+# ---------------------------------------------------------------------------
+# End to end
+# ---------------------------------------------------------------------------
+
+
+def test_pick_two_counts_both_picks(fake_pick_two):
+    """Two picks per row, so twice the row count."""
+    df = summon(
+        "TST",
+        columns=[ColName.NUM_TAKEN],
+        event_type=PICK_TWO,
+        read_cache=False,
+        write_cache=False,
+    )
+    assert df[ColName.NUM_TAKEN].sum() == 2 * fake_pick_two
+
+
+def test_num_drafts_counts_drafts_not_cards(fake_pick_two):
+    """The second pick is the same draft, so this one must not double."""
+    df = summon(
+        "TST",
+        columns=[ColName.NUM_DRAFTS],
+        group_by=[ColName.EVENT_TYPE],
+        event_type=PICK_TWO,
+        read_cache=False,
+        write_cache=False,
+    )
+    assert df[ColName.NUM_DRAFTS].sum() == 1
+
+
+def test_grouping_by_ordinal_separates_the_two_picks(fake_pick_two):
+    df = summon(
+        "TST",
+        columns=[ColName.NUM_TAKEN],
+        group_by=[ColName.PICK_ORDINAL],
+        event_type=PICK_TWO,
+        read_cache=False,
+        write_cache=False,
+    ).sort(ColName.PICK_ORDINAL)
+
+    assert df[ColName.PICK_ORDINAL].to_list() == [1, 2]
+    assert df[ColName.NUM_TAKEN].to_list() == [fake_pick_two, fake_pick_two]
+
+
+def test_single_pick_formats_are_unchanged(fake_pick_two):
+    """Everything above must leave Premier exactly as it was."""
+    df = summon(
+        "TST",
+        columns=[ColName.NUM_TAKEN],
+        event_type=PREMIER,
+        read_cache=False,
+        write_cache=False,
+    )
+    assert df[ColName.NUM_TAKEN].sum() > 0


### PR DESCRIPTION
MSH and OM1 are pick-two formats: each draft row records two picks. The draft
aggregation only ever read `pick`, so every per-pick total for those sets came
out at half its true value.

## Approach

The draft view now projects each pick-two row into two pick events. The second
renames `pick_2` over `pick` on the raw frame, so every expression written
against `pick` — 120+ column specs — counts it without knowing there were two.

`pick_ordinal` (literal 1, or 2 on the second event) is a new `GROUP_BY` column,
available on the draft view for any set. It is what the columns that *cannot* be
doubled key off:

- `num_drafts` counts ordinal 1 only — the second pick is the same draft.
- `pick_maindeck_rate` and `pick_sideboard_in_rate` are nulled on the second
  event. 17Lands derives both from the first pick and publishes no counterpart,
  so carrying them over would describe the wrong card.

Cached pick-two aggregations predate this, so the cache signature gains a
version tag to invalidate them.

## Verification

On real data (MSH), picks per draft now match the single-pick formats:

```
│ PickTwoDraft ┆ 1295178   ┆ 30838      ┆ 106417    ┆ 42.0 │
│ PremierDraft ┆ 2882562   ┆ 68632      ┆ 377514    ┆ 42.0 │
│ TradDraft    ┆ 285095    ┆ 6788       ┆ 41361     ┆ 42.0 │
```

Premier's `num_taken` is unchanged from before, and `num_drafts` is not doubled.
Grouping by `pick_ordinal` reproduces the raw parquet `pick_maindeck_rate` sum
(416353.3173 over 647,589 rows) exactly at ordinal 1, with ordinal 2 adding
nothing.

`pick` and `pick_2` were checked to be genuinely distinct rather than
interchangeable: 18.1% of rows name the lower-rarity card first, and within a
rarity the per-card split has sd 0.081–0.086 against sampling noise of
0.007–0.019. It records click order.

## Known rough edge

Summed over both ordinals, `pick_maindeck_rate` reads `0.0` at ordinal 2 rather
than null, because Polars sums nulls to zero. A user dividing it by `num_taken`
would understate the rate — the numerator counts first picks, the denominator
both. No built-in AGG column touches these two (only `trophy_rate` and `ata`
depend on pick-derived sums), so nothing shipped is wrong; the fix is a real
`pick_2_maindeck_rate` if 17Lands ever publishes one, which the `pick_ordinal`
projection is already shaped to handle.

333 tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)