### PR TITLE
Read the expansion from the filename, not the label

### DIFF
--- a/first_summon.py
+++ b/first_summon.py
@@ -12,9 +12,9 @@ from spells.enums import ColName, EventType
 def event_types_by_set(inv: inventory.Inventory) -> dict[str, list[EventType]]:
     """Each downloaded set, mapped to the event types it actually has.
 
-    Passing one list instead would ask every set for every event type, and
-    asking for one a set does not have fails the read rather than returning
-    nothing for it.
+    `event_type` takes whichever shape suits the question. Leave it out
+    entirely for Premier draft alone, pass a list to ask every set for the same
+    ones, or pass a mapping like this one to give each set its own.
     """
     return {
         set_inv.set_code: sorted(set_inv.events, key=str)

--- a/spells/catalog.py
+++ b/spells/catalog.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from email.utils import parsedate_to_datetime
 from enum import StrEnum
+import re
 import urllib.parse
 
 import requests
@@ -115,9 +116,25 @@ def _link(field) -> str | None:
     for block in field or []:
         for span in block.get("spans", []):
             if span.get("type") == "hyperlink":
-                if url := span.get("data", {}).get("url"):
+                if url := span.get("data", {}).get("url", "").strip():
                     return url
     return None
+
+
+_URL_EXPANSION = re.compile(r"_data_public\.(?P<expansion>.+)\.[^.]+\.csv\.gz$")
+
+
+def _expansion(label: str, *urls: str | None) -> str:
+    """The expansion as it appears in the filename, not as it is displayed.
+
+    The catalog's own field is prose — "Powered Cube" is published as
+    `Cube_-_Powered` — and the filename is what has to match both the download
+    URL and the directory it lands in.
+    """
+    for url in urls:
+        if url and (match := _URL_EXPANSION.search(url)):
+            return match.group("expansion")
+    return label
 
 
 def _event_type(format_name: str) -> EventType | None:
@@ -141,18 +158,20 @@ def parse(document: dict) -> Catalog:
     """
     datasets = []
     for entry in document.get("data", {}).get("datasets", []):
-        expansion = _text(entry.get("expansion"))
+        label = _text(entry.get("expansion"))
         format_name = _text(entry.get("format"))
-        if not expansion or not format_name:
+        if not label or not format_name:
             continue
+        draft_url = _link(entry.get("draft_data"))
+        game_url = _link(entry.get("game_data"))
         datasets.append(
             Dataset(
-                expansion=expansion,
+                expansion=_expansion(label, draft_url, game_url),
                 format_name=format_name,
                 event_type=_event_type(format_name),
                 last_updated=_parse_date(_text(entry.get("last_updated"))),
-                draft_url=_link(entry.get("draft_data")),
-                game_url=_link(entry.get("game_data")),
+                draft_url=draft_url,
+                game_url=game_url,
             )
         )
     return Catalog(datasets=tuple(datasets))

--- a/tests/catalog_test.py
+++ b/tests/catalog_test.py
@@ -45,6 +45,90 @@ def test_parse_marks_unpublished_dataset_as_no_url(parsed):
     assert khm.game_url is not None
 
 
+def _document(label: str, draft_url: str | None, game_url: str | None = None) -> dict:
+    def rich_text(text: str) -> list[dict]:
+        return [{"type": "paragraph", "text": text, "spans": []}]
+
+    def link(url: str | None) -> list[dict]:
+        if url is None:
+            return rich_text("-")
+        return [
+            {
+                "type": "paragraph",
+                "text": "link",
+                "spans": [{"type": "hyperlink", "data": {"url": url}}],
+            }
+        ]
+
+    return {
+        "data": {
+            "datasets": [
+                {
+                    "expansion": rich_text(label),
+                    "format": rich_text("PremierDraft"),
+                    "last_updated": rich_text("2026-07-26"),
+                    "draft_data": link(draft_url),
+                    "game_data": link(game_url),
+                }
+            ]
+        }
+    }
+
+
+CUBE_DRAFT_URL = (
+    "https://17lands-public.s3.amazonaws.com/analysis_data/draft_data/"
+    "draft_data_public.Cube_-_Powered.PremierDraft.csv.gz"
+)
+
+
+def test_expansion_comes_from_the_filename_not_the_display_name():
+    """17Lands displays the Powered Cube as prose but publishes it as
+    `Cube_-_Powered`; the filename is what a download has to ask for."""
+    cat = catalog.parse(_document("Powered Cube", CUBE_DRAFT_URL))
+
+    assert cat.expansions == ("Cube_-_Powered",)
+    assert cat.get("Cube_-_Powered", EventType.PREMIER) is not None
+    assert cat.get("Powered Cube", EventType.PREMIER) is None
+
+
+def test_a_derived_expansion_rebuilds_its_own_url():
+    """The templated fallback and the published link have to agree, or an
+    offline `add` would ask for a name that was never published."""
+    cat = catalog.parse(_document("Powered Cube", CUBE_DRAFT_URL))
+
+    assert (
+        catalog.fallback_url("Cube_-_Powered", View.DRAFT, EventType.PREMIER)
+        == CUBE_DRAFT_URL
+    )
+    assert cat.get("Cube_-_Powered", EventType.PREMIER).draft_url == CUBE_DRAFT_URL
+
+
+def test_expansion_falls_back_to_the_label_when_nothing_is_published():
+    cat = catalog.parse(_document("KHM", None, None))
+
+    assert cat.expansions == ("KHM",)
+
+
+def test_expansion_is_read_from_game_data_when_draft_is_unpublished():
+    game_url = (
+        "https://17lands-public.s3.amazonaws.com/analysis_data/game_data/"
+        "game_data_public.Cube_-_Powered.PremierDraft.csv.gz"
+    )
+    cat = catalog.parse(_document("Powered Cube", None, game_url))
+
+    assert cat.expansions == ("Cube_-_Powered",)
+
+
+def test_urls_are_stripped_of_stray_whitespace():
+    """Several game links are authored with a leading space. requests happens
+    to tolerate it, so this keeps a latent break from becoming a real one."""
+    padded = f"  {CUBE_DRAFT_URL} "
+    cat = catalog.parse(_document("Powered Cube", padded))
+
+    assert cat.datasets[0].draft_url == CUBE_DRAFT_URL
+    assert cat.expansions == ("Cube_-_Powered",)
+
+
 def test_parse_keeps_unsupported_formats_but_leaves_event_type_unset(parsed):
     sealed = [d for d in parsed.datasets if d.format_name == "Sealed"]
     assert len(sealed) == 1


### PR DESCRIPTION
`spells add` for the Powered Cube asked S3 for an object that does not exist,
404'd, and left an empty `external/Powered Cube` directory behind.

## Cause

The catalog's `expansion` field is prose. For 127 of 129 datasets it happens to
equal the published filename, so it has been serving as the set code. The
Powered Cube is the exception:

| displayed | published as |
|---|---|
| `Powered Cube` | `Cube_-_Powered` |

Deriving the expansion from the URL instead makes the catalog agree with both
the download and the directory it lands in. Confirmed against S3 — only
`Cube_-_Powered` resolves (92,791,954 bytes); `Powered Cube` and `Cube+-+Powered`
are both missing.

Since the derived name round-trips through `fallback_url`, the offline `add`
path is fixed by the same change, with no second place to keep in sync.

## Also stripped

Four game links (TLA, ECL, TMT, SOS TradDraft) are authored with a leading
space. `requests` tolerates it today, so this is latent rather than broken —
stripping on the way in keeps it that way.

## Note for existing users

A set added before this fix has a directory named after the display name. Only
the cube is affected, and only the empty failed-add directory; nothing needs
migrating, but `external/Powered Cube` can be removed.

5 new tests, 338 passing, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)