### PR TITLE
Read the ALSA depth off the event type of the row

### DIFF
--- a/spells/columns.py
+++ b/spells/columns.py
@@ -16,6 +16,12 @@ class ColSpec:
 
 P1P1_MISSING_SETS = frozenset({"TLA", "TMT", "ECL"})
 
+PACKS_SEEN_COL = (
+    pl.when(pl.col(ColName.EVENT_TYPE) == EventType.PICK_TWO)
+    .then(pl.lit(4))
+    .otherwise(pl.lit(8))
+)
+
 
 @dataclass(frozen=True)
 class ColDef:
@@ -76,9 +82,11 @@ _specs: dict[str, ColSpec] = {
     ColName.FORMAT_DAY: ColSpec(
         col_type=ColType.GROUP_BY,
         expr=lambda set_context: (
-            pl.col(ColName.DRAFT_DATE) - pl.lit(set_context["release_date"])
-        ).dt.total_days()
-        + 1,
+            (
+                pl.col(ColName.DRAFT_DATE) - pl.lit(set_context["release_date"])
+            ).dt.total_days()
+            + 1
+        ),
     ),
     ColName.DRAFT_DAY_OF_WEEK: ColSpec(
         col_type=ColType.GROUP_BY,
@@ -176,8 +184,10 @@ _specs: dict[str, ColSpec] = {
     ),
     ColName.PICK_INDEX: ColSpec(
         col_type=ColType.GROUP_BY,
-        expr=lambda set_context: pl.col(ColName.PICK_NUMBER)
-        + pl.col(ColName.PACK_NUMBER) * set_context["picks_per_pack"],
+        expr=lambda set_context: (
+            pl.col(ColName.PICK_NUMBER)
+            + pl.col(ColName.PACK_NUMBER) * set_context["picks_per_pack"]
+        ),
     ),
     ColName.TAKEN_AT: ColSpec(
         col_type=ColType.PICK_SUM,
@@ -210,11 +220,8 @@ _specs: dict[str, ColSpec] = {
         col_type=ColType.FILTER_ONLY,
         views=[View.DRAFT],
     ),
+    # Added to distinguish pick 1 pass from pick 2 pass for PICK_SUM columns
     ColName.PICK_ORDINAL: ColSpec(
-        # 1 everywhere except the second pick of a pick-two row, so a column
-        # that only holds for the first can say which it means. Grouping by it
-        # separates the card a drafter reached for from the one they took
-        # alongside it — the two are not interchangeable.
         col_type=ColType.GROUP_BY,
         views=[View.DRAFT],
     ),
@@ -232,21 +239,22 @@ _specs: dict[str, ColSpec] = {
     ),
     ColName.LAST_SEEN: ColSpec(
         col_type=ColType.NAME_SUM,
-        expr=lambda name: pl.col(f"pack_card_{name}")
-        * pl.min_horizontal(ColName.PICK_NUM, 8),
+        expr=lambda name: (
+            pl.col(f"pack_card_{name}")
+            * pl.min_horizontal(ColName.PICK_NUM, PACKS_SEEN_COL)
+        ),
     ),
     ColName.NUM_SEEN: ColSpec(
         col_type=ColType.NAME_SUM,
-        expr=lambda name: pl.col(f"pack_card_{name}") * (pl.col(ColName.PICK_NUM) <= 8),
+        expr=lambda name: (
+            pl.col(f"pack_card_{name}") * (pl.col(ColName.PICK_NUM) <= PACKS_SEEN_COL)
+        ),
     ),
     ColName.POOL: ColSpec(
         col_type=ColType.NAME_SUM,
         views=[View.DRAFT],
     ),
     ColName.POOL_COUNT: ColSpec(
-        # Cards in the pool before this pick, summed across pool_ columns. Note
-        # this undercounts multi-pick formats (PickTwoDraft), whose public
-        # pool_ columns only track the `pick` card, not pick_2.
         col_type=ColType.PICK_SUM,
         views=[View.DRAFT],
         expr=lambda names: pl.sum_horizontal(
@@ -440,13 +448,16 @@ _specs: dict[str, ColSpec] = {
     ),
     ColName.DECK_MANA_VALUE: ColSpec(
         col_type=ColType.NAME_SUM,
-        expr=lambda name, card_context: card_context[name][ColName.MANA_VALUE]
-        * pl.col(f"deck_{name}"),
+        expr=lambda name, card_context: (
+            card_context[name][ColName.MANA_VALUE] * pl.col(f"deck_{name}")
+        ),
     ),
     ColName.DECK_LANDS: ColSpec(
         col_type=ColType.NAME_SUM,
-        expr=lambda name, card_context: pl.col(f"deck_{name}")
-        * (1 if "Land" in card_context[name][ColName.CARD_TYPE] else 0),
+        expr=lambda name, card_context: (
+            pl.col(f"deck_{name}")
+            * (1 if "Land" in card_context[name][ColName.CARD_TYPE] else 0)
+        ),
     ),
     ColName.DECK_SPELLS: ColSpec(
         col_type=ColType.NAME_SUM,

--- a/spells/draft_data.py
+++ b/spells/draft_data.py
@@ -30,16 +30,8 @@ from spells.card_data_files import base_ratings_df, CacheUsage
 
 DF = TypeVar("DF", pl.LazyFrame, pl.DataFrame)
 
-# measured against the first pick of a row and published without a counterpart
-# for the second, so they describe only that card
 FIRST_PICK_ONLY = (ColName.PICK_MAINDECK_RATE, ColName.PICK_SIDEBOARD_IN_RATE)
-
-# every draft row is a first pick until a pick-two row is split into two
-PICK_ORDINAL_FIRST = pl.lit(1, dtype=pl.Int8).alias(ColName.PICK_ORDINAL)
-
-# bumped when the meaning of a pick-two aggregate changes, since the column
-# definitions can stay identical while every total moves
-PICK_TWO_AGG_VERSION = 3
+PICK_TWO_AGG_VERSION = 4
 
 
 def _cache_key(args) -> str:
@@ -405,40 +397,24 @@ def _fetch_or_cache(
 def _prepared(
     frame: pl.LazyFrame, cols_for_view: frozenset[str], m: manifest.Manifest
 ) -> pl.LazyFrame:
-    """Resolve a base view's columns and apply the manifest filter.
-
-    Taken per frame rather than once, because the per-pick and per-pack
-    aggregations do not agree on how many rows a pick-two row is.
-    """
     selected = _view_select(frame, cols_for_view, m.col_def_map, is_agg_view=False)
     return selected.filter(m.filter.expr) if m.filter is not None else selected
+
+
+def _pick_ordinal_col(ordinal: int) -> pl.Expr:
+    return pl.lit(ordinal, dtype=pl.Int8).alias(ColName.PICK_ORDINAL)
 
 
 def _pick_events(
     draft_df: pl.LazyFrame, view: View, event_type: EventType
 ) -> pl.LazyFrame:
-    """The draft view as one row per pick rather than per pick row.
-
-    A pick-two row records two picks, so it becomes two rows: the second is the
-    same row with `pick_2` standing in as `pick`. Doing this on the raw frame,
-    before any column expression is evaluated, means every expression written
-    against `pick` counts both without knowing there were two.
-
-    `pick_ordinal` says which of the two a row is, so a column that only holds
-    for the first can say so — `num_drafts` counts drafts rather than cards,
-    and 17Lands computes the maindeck rates from the first pick alone.
-    """
-    first = draft_df.with_columns(PICK_ORDINAL_FIRST)
+    first = draft_df.with_columns(_pick_ordinal_col(1))
     if view != View.DRAFT or event_type != EventType.PICK_TWO:
         return first
 
     second = draft_df.drop(ColName.PICK).rename({ColName.PICK_2: ColName.PICK})
     second = second.with_columns(
-        pl.lit(2, dtype=pl.Int8).alias(ColName.PICK_ORDINAL),
-        # 17Lands derives these from the first pick and publishes no
-        # counterpart for the second, so they are absent here rather than
-        # describing the wrong card. Should a `pick_2_` counterpart appear,
-        # rename it in beside `pick` instead of nulling.
+        _pick_ordinal_col(2),
         *(
             pl.lit(None, dtype=pl.Float64).alias(col)
             for col in FIRST_PICK_ONLY
@@ -499,12 +475,14 @@ def _base_agg_df(
         # per pack, and both picks of a pick-two row come out of one pack, so
         # this counts the row once however many picks it records
         per_pack_df = (
-            _prepared(raw_df.with_columns(PICK_ORDINAL_FIRST), cols_for_view, m)
+            _prepared(raw_df.with_columns(_pick_ordinal_col(1)), cols_for_view, m)
             if name_sum_cols
             else None
         )
 
         for col in name_sum_cols:
+            assert per_pack_df is not None
+
             names = get_names(set_code)
             expr = tuple(pl.col(f"{col}_{name}").alias(name) for name in names)
 
@@ -546,8 +524,6 @@ def _base_agg_df(
     return joined_df
 
 
-# one event type for every set, several for every set, or a different choice
-# per set
 EventTypeSpec = (
     EventType
     | str
@@ -559,17 +535,6 @@ EventTypeSpec = (
 def _event_type_cells(
     event_type: EventTypeSpec, codes: list[str]
 ) -> list[tuple[str, EventType]]:
-    """Which (set, event type) pairs to aggregate.
-
-    One value or list applies to every set, which is the product this has
-    always taken. A dict gives each set its own, for a collection where the
-    sets are not all held in the same formats — asking for one a set does not
-    have is an error rather than an empty result, so the product is only right
-    when every set has every event type named.
-
-    A dict must name every set asked for: defaulting the rest to Premier would
-    turn a mistyped set code into a silently different query.
-    """
     if isinstance(event_type, dict):
         if missing := [code for code in codes if code not in event_type]:
             raise ValueError(
@@ -586,7 +551,6 @@ def _event_type_cells(
         chosen = chosen if isinstance(chosen, list) else [chosen]
         if not chosen:
             raise ValueError(f"No event type given for {code}")
-        # dict.fromkeys rather than set: cell order drives the frame order
         cells.extend((code, et) for et in dict.fromkeys(EventType(e) for e in chosen))
     return cells
 
@@ -623,10 +587,6 @@ def _normalize_context_keys(
 
 
 def _finalize_agg(concat_dfs: list[pl.DataFrame], m: manifest.Manifest) -> pl.DataFrame:
-    """Shared tail of summon()/card_ratings_view(): concat per-cell aggregate
-    frames, apply the user's group_by (re-aggregating if it's coarser than the
-    base grouping), and run the final AGG-stage column selection.
-    """
     full_agg_df = pl.concat(concat_dfs, how="vertical")
 
     if m.group_by:
@@ -846,7 +806,7 @@ def lazy_select(
     )
 
     df_path = cache.data_file_path(set_code, view, event_type)
-    base_view_df = pl.scan_parquet(df_path).with_columns(PICK_ORDINAL_FIRST)
+    base_view_df = pl.scan_parquet(df_path).with_columns(_pick_ordinal_col(1))
 
     select_cols = frozenset(columns)
 

--- a/spells/external.py
+++ b/spells/external.py
@@ -45,13 +45,7 @@ def _add(
         set_code, View.GAME, event_type=event_type, force_download=force_download
     )
 
-    if event_type == EventType.PICK_TWO:
-        console.info(
-            f"Skipping set context for {event_type} "
-            "(summon does not support multi-pick formats yet)",
-        )
-    else:
-        get_set_context(set_code, event_type=event_type, force_download=force_download)
+    get_set_context(set_code, event_type=event_type, force_download=force_download)
     return 0
 
 

--- a/spells/inventory.py
+++ b/spells/inventory.py
@@ -98,10 +98,7 @@ class EventFiles:
 
     @property
     def missing(self) -> tuple[str, ...]:
-        # summon skips set context for multi-pick formats, so pick-two sets are
-        # complete without one.
-        expected = ("draft", "game") if self.is_pick_two else DATASET_VIEWS
-        return tuple(v for v in expected if getattr(self, v) is None)
+        return tuple(v for v in DATASET_VIEWS if getattr(self, v) is None)
 
     @property
     def is_pick_two(self) -> bool:

--- a/tests/external_test.py
+++ b/tests/external_test.py
@@ -64,17 +64,17 @@ def test_add_traditional_downloads_full_set_with_context(record_io):
     assert record_io["context"] == [("TST", EventType.TRADITIONAL)]
 
 
-def test_add_pick_two_skips_only_set_context(record_io):
+def test_add_pick_two_builds_a_set_context_like_any_other(record_io):
+    """The context carries the ALSA mask, which is the one thing a pick-two
+    format does not share with the rest."""
     external._add("OM1", event_type=EventType.PICK_TWO)
 
-    # draft + game + card download identically; only the summon-driven set
-    # context is skipped for multi-pick formats
     assert record_io["download"] == [
         ("OM1", View.DRAFT, EventType.PICK_TWO),
         ("OM1", View.GAME, EventType.PICK_TWO),
     ]
     assert record_io["card"] == [("OM1", FAKE_NAMES)]
-    assert record_io["context"] == []
+    assert record_io["context"] == [("OM1", EventType.PICK_TWO)]
 
 
 def test_refresh_card_only_rebuilds_from_existing_draft_file(record_io, monkeypatch):

--- a/tests/inventory_test.py
+++ b/tests/inventory_test.py
@@ -116,8 +116,10 @@ def test_incomplete_set_is_flagged(data_home):
     assert "game" in anomaly.detail and "context" in anomaly.detail
 
 
-def test_pick_two_set_is_complete_without_context(data_home):
-    # summon skips set context for multi-pick formats
+def test_pick_two_set_needs_a_context_like_any_other(data_home):
+    """It used to be excused one, back when summon ignored the second pick.
+    The context carries the ALSA mask now, so a set without one reads a pack
+    eight picks deep when it should read four."""
     write_external(
         data_home,
         "OM1",
@@ -127,8 +129,8 @@ def test_pick_two_set_is_complete_without_context(data_home):
     )
     inv = inventory.scan()
 
-    assert inv.sets["OM1"].events[EventType.PICK_TWO].is_complete
-    assert inv.sets["OM1"].anomalies == []
+    assert not inv.sets["OM1"].events[EventType.PICK_TWO].is_complete
+    assert inv.sets["OM1"].events[EventType.PICK_TWO].missing == ("context",)
 
 
 def test_multiple_event_types(data_home):

--- a/tests/pick_two_test.py
+++ b/tests/pick_two_test.py
@@ -147,17 +147,14 @@ def test_per_pack_and_per_pick_columns_agree_in_one_query(fake_pick_two):
 
 
 def test_a_pick_two_pack_is_seen_half_as_many_picks_deep():
-    """17Lands stops calling a card seen a fixed distance into the pack. Two
-    cards a pick covers that distance in half the picks, and their published
-    ALSA agrees: at 4 it matches per-card to 0.01, at 8 it is off by 0.25."""
+    """Two cards a pick covers the same ground in half the picks."""
     rows = pl.DataFrame({ColName.EVENT_TYPE: [str(PREMIER), str(PICK_TWO)]})
 
     assert rows.select(PACKS_SEEN_COL.alias("d"))["d"].to_list() == [8, 4]
 
 
 def test_the_depth_is_read_off_the_row(fake_pick_two):
-    """One query spanning both formats gives each its own depth, which an
-    argument threaded in from the caller could not do."""
+    """One query spanning both formats gives each its own depth."""
     rows = pl.DataFrame(
         {ColName.EVENT_TYPE: [str(PICK_TWO), str(PREMIER), str(PICK_TWO)]}
     )

--- a/tests/pick_two_test.py
+++ b/tests/pick_two_test.py
@@ -11,7 +11,8 @@ import polars as pl
 import pytest
 
 from spells import summon
-from spells.draft_data import PICK_ORDINAL_FIRST, _pick_events
+from spells.columns import PACKS_SEEN_COL
+from spells.draft_data import _pick_events, _pick_ordinal_col
 from spells.enums import ColName, EventType, View
 
 PREMIER = EventType.PREMIER
@@ -92,7 +93,7 @@ def test_first_pick_only_columns_survive_on_the_first_event(rows):
 def test_a_row_level_view_keeps_one_row_and_both_picks(rows):
     """`lazy_select` reconstructs drafts, so it must not split anything — but
     the column still has to resolve, since one set of definitions serves both."""
-    out = rows.with_columns(PICK_ORDINAL_FIRST).collect()
+    out = rows.with_columns(_pick_ordinal_col(1)).collect()
 
     assert len(out) == 2
     assert ColName.PICK_2 in out.columns
@@ -143,6 +144,37 @@ def test_per_pack_and_per_pick_columns_agree_in_one_query(fake_pick_two):
     )
     assert df[ColName.NUM_SEEN].sum() == fake_pick_two * len(df)
     assert df[ColName.NUM_TAKEN].sum() == 2 * fake_pick_two
+
+
+def test_a_pick_two_pack_is_seen_half_as_many_picks_deep():
+    """17Lands stops calling a card seen a fixed distance into the pack. Two
+    cards a pick covers that distance in half the picks, and their published
+    ALSA agrees: at 4 it matches per-card to 0.01, at 8 it is off by 0.25."""
+    rows = pl.DataFrame({ColName.EVENT_TYPE: [str(PREMIER), str(PICK_TWO)]})
+
+    assert rows.select(PACKS_SEEN_COL.alias("d"))["d"].to_list() == [8, 4]
+
+
+def test_the_depth_is_read_off_the_row(fake_pick_two):
+    """One query spanning both formats gives each its own depth, which an
+    argument threaded in from the caller could not do."""
+    rows = pl.DataFrame(
+        {ColName.EVENT_TYPE: [str(PICK_TWO), str(PREMIER), str(PICK_TWO)]}
+    )
+
+    assert rows.select(PACKS_SEEN_COL.alias("d"))["d"].to_list() == [4, 8, 4]
+
+
+def test_both_formats_aggregate_together(fake_pick_two):
+    df = summon(
+        "TST",
+        columns=[ColName.NUM_SEEN],
+        group_by=[ColName.EVENT_TYPE],
+        event_type=[PREMIER, PICK_TWO],
+        read_cache=False,
+        write_cache=False,
+    )
+    assert set(df[ColName.EVENT_TYPE]) == {str(PREMIER), str(PICK_TWO)}
 
 
 def test_num_drafts_counts_drafts_not_cards(fake_pick_two):


### PR DESCRIPTION
Two commits, separable.

## 1. The ALSA depth

17Lands stops calling a card "seen" a fixed distance into the pack, and spells
hardcoded that as eight picks. A pick-two format covers the same ground in
four, so every pick-two ALSA was measured against a pack twice as deep as the
one drafters saw.

The event type is a column on both views, so the depth reads off the row
rather than being threaded in — a query spanning formats gets each one's own
depth for free.

Premier and Traditional are unchanged (MSH Premier `num_seen` 17,295,502
before and after). `PICK_TWO_AGG_VERSION` -> 4.

## 2. The set context

Independent of the above. Pick-two sets were skipped when building a set
context, on the reasoning that summon ignored their second pick anyway —
obsolete since #37. The omission left `format_day`, `format_week`, and
`pick_index` unavailable for those formats.

`external.py` no longer skips it and `inventory.py` no longer excuses pick-two
from completeness, so a set still missing one reports:

```
OM1: PickTwoDraft is missing context
```

Drop this commit if you would rather it went on its own.

376 tests pass on each commit independently, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
